### PR TITLE
Added CheckBytes derivation to ModuleError

### DIFF
--- a/piecrust-uplink/src/state.rs
+++ b/piecrust-uplink/src/state.rs
@@ -4,6 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+use bytecheck::CheckBytes;
 use rkyv::{
     archived_root,
     ser::serializers::{BufferScratch, BufferSerializer, CompositeSerializer},
@@ -68,6 +69,7 @@ use crate::ModuleId;
 use core::ops::{Deref, DerefMut};
 
 #[derive(Debug, Archive, Serialize, Deserialize)]
+#[archive_attr(derive(CheckBytes))]
 pub enum ModuleError {
     Panic,
     OutOfGas,

--- a/piecrust/src/instance.rs
+++ b/piecrust/src/instance.rs
@@ -64,7 +64,7 @@ impl DerefMut for Env {
 }
 
 impl Env {
-    pub fn self_instance<'a, 'b>(&'a self) -> &'b mut WrappedInstance {
+    pub fn self_instance<'b>(&self) -> &'b mut WrappedInstance {
         self.session
             .nth_from_top(0)
             .expect("there should be at least one element in the call stack")

--- a/piecrust/src/session.rs
+++ b/piecrust/src/session.rs
@@ -67,7 +67,7 @@ impl StackElement {
         }
     }
 
-    fn instance<'a, 'b>(&'a self) -> &'b mut WrappedInstance {
+    fn instance<'b>(&self) -> &'b mut WrappedInstance {
         unsafe { &mut *self.instance }
     }
 }
@@ -242,8 +242,8 @@ impl<'c> Session<'c> {
         self.spent
     }
 
-    pub(crate) fn nth_from_top<'a, 'b>(
-        &'a self,
+    pub(crate) fn nth_from_top<'b>(
+        &self,
         n: usize,
     ) -> Option<StackElementView<'b>> {
         let stack = self.callstack.read();
@@ -262,8 +262,8 @@ impl<'c> Session<'c> {
         }
     }
 
-    pub(crate) fn push_callstack<'a, 'b>(
-        &'a self,
+    pub(crate) fn push_callstack<'b>(
+        &self,
         module_id: ModuleId,
         instance: WrappedInstance,
         limit: u64,


### PR DESCRIPTION
Added CheckBytes derivation to ModuleError - this is needed to fix Rusk serialization problem, at the same time it fixes the only struct/enum in Piecrust which has Archive derivation yet is lacking CheckBytes derivation.
Fixes issue #116