### PR TITLE
Implement call atomicity

### DIFF
--- a/modules/callcenter/src/lib.rs
+++ b/modules/callcenter/src/lib.rs
@@ -82,7 +82,8 @@ impl Callcenter {
         let caller = uplink::caller();
 
         match caller.is_uninitialized() {
-            true => uplink::query(self_id, "call_self", &()),
+            true => uplink::query(self_id, "call_self", &())
+                .expect("querying self should succeed"),
             false => Ok(caller == self_id),
         }
     }

--- a/modules/crossover/src/lib.rs
+++ b/modules/crossover/src/lib.rs
@@ -76,6 +76,7 @@ impl Crossover {
 
     /// Return crossover value
     pub fn crossover(&self) -> i32 {
+        uplink::debug!("Returning crossover: {}", self.crossover);
         self.crossover
     }
 

--- a/piecrust-uplink/src/helpers.rs
+++ b/piecrust-uplink/src/helpers.rs
@@ -29,15 +29,14 @@ where
         let slice = &buf[..arg_len as usize];
 
         let aa: &A::Archived = unsafe { archived_root::<A>(slice) };
-        let a: A = aa.deserialize(&mut rkyv::Infallible).unwrap();
+        let a: A = aa.deserialize(&mut Infallible).unwrap();
 
         let ret = f(a);
 
         let mut sbuf = [0u8; SCRATCH_BUF_BYTES];
         let scratch = BufferScratch::new(&mut sbuf);
         let ser = BufferSerializer::new(buf);
-        let mut composite =
-            CompositeSerializer::new(ser, scratch, rkyv::Infallible);
+        let mut composite = CompositeSerializer::new(ser, scratch, Infallible);
         composite.serialize_value(&ret).expect("infallible");
         composite.pos() as u32
     })
@@ -56,14 +55,13 @@ where
     with_arg_buf(|buf| {
         let slice = &buf[..arg_len as usize];
         let aa: &A::Archived = unsafe { archived_root::<A>(slice) };
-        let a: A = aa.deserialize(&mut rkyv::Infallible).unwrap();
+        let a: A = aa.deserialize(&mut Infallible).unwrap();
         let ret = f(a);
 
         let mut sbuf = [0u8; SCRATCH_BUF_BYTES];
         let scratch = BufferScratch::new(&mut sbuf);
         let ser = BufferSerializer::new(buf);
-        let mut composite =
-            CompositeSerializer::new(ser, scratch, rkyv::Infallible);
+        let mut composite = CompositeSerializer::new(ser, scratch, Infallible);
         composite.serialize_value(&ret).expect("infallible");
         composite.pos() as u32
     })

--- a/piecrust/src/imports.rs
+++ b/piecrust/src/imports.rs
@@ -222,8 +222,8 @@ fn emit(mut fenv: FunctionEnvMut<Env>, arg_len: u32) {
     env.emit(arg_len)
 }
 
-fn host_debug(fenv: FunctionEnvMut<Env>, msg_ofs: i32, msg_len: u32) {
-    let env = fenv.data();
+fn host_debug(mut fenv: FunctionEnvMut<Env>, msg_ofs: i32, msg_len: u32) {
+    let env = fenv.data_mut();
 
     env.self_instance().with_memory(|mem| {
         let slice = &mem[msg_ofs as usize..][..msg_len as usize];

--- a/piecrust/src/session.rs
+++ b/piecrust/src/session.rs
@@ -5,7 +5,6 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 pub mod call_stack;
-use call_stack::{CallStack, StackElementView};
 
 use std::borrow::Cow;
 use std::collections::BTreeMap;
@@ -30,6 +29,8 @@ use crate::vm::HostQueries;
 use crate::Error;
 use crate::Error::PersistenceError;
 
+use call_stack::{CallStack, StackElementView};
+
 const DEFAULT_LIMIT: u64 = 65_536;
 const MAX_META_SIZE: usize = 65_536;
 
@@ -40,9 +41,11 @@ pub struct Session {
     callstack: Arc<RwLock<CallStack>>,
     debug: Arc<RwLock<Vec<String>>>,
     events: Arc<RwLock<Vec<Event>>>,
-    data: Arc<RwLock<HostData>>,
+    data: Arc<RwLock<Metadata>>,
+
     module_session: ModuleSession,
     host_queries: HostQueries,
+
     limit: u64,
     spent: u64,
 }
@@ -56,7 +59,7 @@ impl Session {
             callstack: Arc::new(RwLock::new(CallStack::new())),
             debug: Arc::new(RwLock::new(vec![])),
             events: Arc::new(RwLock::new(vec![])),
-            data: Arc::new(RwLock::new(HostData::new())),
+            data: Arc::new(RwLock::new(Metadata::new())),
             module_session,
             host_queries,
             limit: DEFAULT_LIMIT,
@@ -288,11 +291,12 @@ impl Session {
     }
 }
 
-struct HostData {
+#[derive(Debug)]
+pub struct Metadata {
     data: BTreeMap<Cow<'static, str>, Vec<u8>>,
 }
 
-impl HostData {
+impl Metadata {
     fn new() -> Self {
         Self {
             data: BTreeMap::new(),

--- a/piecrust/src/session.rs
+++ b/piecrust/src/session.rs
@@ -150,7 +150,7 @@ impl Session {
         ser.serialize_value(arg).expect("Infallible");
         let pos = ser.pos();
 
-        let ret_bytes = self.re_execute_until_ok(Call {
+        let ret_bytes = self.execute_until_ok(Call {
             ty: CallType::Q,
             module,
             fname: method_name.to_string(),
@@ -184,7 +184,7 @@ impl Session {
         ser.serialize_value(arg).expect("Infallible");
         let pos = ser.pos();
 
-        let ret_bytes = self.re_execute_until_ok(Call {
+        let ret_bytes = self.execute_until_ok(Call {
             ty: CallType::T,
             module,
             fname: method_name.to_string(),
@@ -385,8 +385,8 @@ impl Session {
     }
 
     /// Execute the call and re-execute until the call errors with only itself
-    /// in the call stack.
-    fn re_execute_until_ok(&mut self, call: Call) -> Result<Vec<u8>, Error> {
+    /// in the call stack, or succeeds.
+    fn execute_until_ok(&mut self, call: Call) -> Result<Vec<u8>, Error> {
         // If the call succeeds at first run, then we can proceed with adding it
         // to the call history and return.
         match self.call_if_not_error(call) {

--- a/piecrust/src/session/call_stack.rs
+++ b/piecrust/src/session/call_stack.rs
@@ -4,12 +4,11 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::instance::WrappedInstance;
-use std::collections::btree_map::Entry;
-
-use std::collections::BTreeMap;
+use std::collections::btree_map::{BTreeMap, Entry};
 
 use piecrust_uplink::ModuleId;
+
+use crate::instance::WrappedInstance;
 
 #[derive(Debug, Default)]
 pub struct CallStack {

--- a/piecrust/src/session/call_stack.rs
+++ b/piecrust/src/session/call_stack.rs
@@ -44,6 +44,18 @@ impl CallStack {
         self.stack.push(StackElement { module_id, limit });
     }
 
+    /// Return the length of the call stack.
+    pub fn len(&self) -> usize {
+        self.stack.len()
+    }
+
+    /// Remove all elements from the stack.
+    pub fn clear(&mut self) {
+        while self.len() > 0 {
+            self.pop();
+        }
+    }
+
     /// Push an element to the call stack.
     ///
     /// # Panics

--- a/piecrust/src/store/session.rs
+++ b/piecrust/src/store/session.rs
@@ -160,6 +160,11 @@ impl ModuleSession {
         }
     }
 
+    /// Clear all deployed deployed or otherwise instantiated modules.
+    pub fn clear_modules(&mut self) {
+        self.modules.clear();
+    }
+
     /// Deploys bytecode to the module store.
     ///
     /// The module ID returned is computed using the `blake3` hash of the given

--- a/piecrust/src/vm.rs
+++ b/piecrust/src/vm.rs
@@ -29,7 +29,8 @@ impl VM {
     where
         P: Into<PathBuf>,
     {
-        let store = ModuleStore::new(dir).map_err(PersistenceError)?;
+        let store = ModuleStore::new(dir)
+            .map_err(|err| PersistenceError(Arc::new(err)))?;
         Ok(Self {
             host_queries: HostQueries::default(),
             store,
@@ -38,10 +39,11 @@ impl VM {
 
     /// Creates a new virtual machine using a temporary directory.
     pub fn ephemeral() -> Result<Self, Error> {
-        let tmp = tempdir().map_err(PersistenceError)?;
+        let tmp = tempdir().map_err(|err| PersistenceError(Arc::new(err)))?;
         let tmp = tmp.path().to_path_buf();
 
-        let store = ModuleStore::new(tmp).map_err(PersistenceError)?;
+        let store = ModuleStore::new(tmp)
+            .map_err(|err| PersistenceError(Arc::new(err)))?;
 
         Ok(Self {
             host_queries: HostQueries::default(),
@@ -59,8 +61,10 @@ impl VM {
     }
 
     pub fn session(&self, base: [u8; 32]) -> Result<Session, Error> {
-        let module_session =
-            self.store.session(base).map_err(PersistenceError)?;
+        let module_session = self
+            .store
+            .session(base)
+            .map_err(|err| PersistenceError(Arc::new(err)))?;
         Ok(Session::new(module_session, self.host_queries.clone()))
     }
 
@@ -91,12 +95,16 @@ impl VM {
     /// [`write`]: fs::write
     /// [`delete_commit`]: VM::delete_commit
     pub fn squash_commit(&self, root: [u8; 32]) -> Result<(), Error> {
-        self.store.squash_commit(root).map_err(PersistenceError)
+        self.store
+            .squash_commit(root)
+            .map_err(|err| PersistenceError(Arc::new(err)))
     }
 
     /// Deletes the given commit from disk.
     pub fn delete_commit(&self, root: [u8; 32]) -> Result<(), Error> {
-        self.store.delete_commit(root).map_err(PersistenceError)
+        self.store
+            .delete_commit(root)
+            .map_err(|err| PersistenceError(Arc::new(err)))
     }
 
     /// Return the root directory of the virtual machine.

--- a/piecrust/tests/callcenter.rs
+++ b/piecrust/tests/callcenter.rs
@@ -5,7 +5,9 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use piecrust::{module_bytecode, Error, VM};
-use piecrust_uplink::{ModuleId, RawQuery, RawResult, RawTransaction};
+use piecrust_uplink::{
+    ModuleError, ModuleId, RawQuery, RawResult, RawTransaction,
+};
 
 #[test]
 pub fn cc_read_counter() -> Result<(), Error> {
@@ -148,8 +150,10 @@ pub fn cc_caller() -> Result<(), Error> {
 
     let center_id = session.deploy(module_bytecode!("callcenter"))?;
 
-    let value: bool = session.query(center_id, "call_self", &())?;
-    assert!(value);
+    let value: Result<bool, ModuleError> =
+        session.query(center_id, "call_self", &())?;
+
+    assert!(value.expect("should succeed"));
 
     Ok(())
 }

--- a/piecrust/tests/crossover.rs
+++ b/piecrust/tests/crossover.rs
@@ -24,6 +24,7 @@ fn crossover() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
     let mut session = vm.genesis_session();
+    session.set_point_limit(u64::MAX / 100);
 
     session.deploy_with_id(CROSSOVER_ONE, module_bytecode!("crossover"))?;
     session.deploy_with_id(CROSSOVER_TWO, module_bytecode!("crossover"))?;

--- a/piecrust/tests/crossover.rs
+++ b/piecrust/tests/crossover.rs
@@ -29,22 +29,28 @@ fn crossover() -> Result<(), Error> {
     session.deploy_with_id(CROSSOVER_ONE, module_bytecode!("crossover"))?;
     session.deploy_with_id(CROSSOVER_TWO, module_bytecode!("crossover"))?;
 
-    const CROSSOVER_TO_SET: i32 = 10;
+    // These value should not be set to `INITIAL_VALUE` in the contract.
+    const CROSSOVER_TO_SET: i32 = 42;
+    const CROSSOVER_TO_SET_FORWARD: i32 = 314;
+    const CROSSOVER_TO_SET_BACK: i32 = 272;
 
-    let state_is_ok: bool = session.transact(
+    // This call will fail if the state is inconsistent. Check the contract for
+    // more details.
+    session.transact::<_, ()>(
         CROSSOVER_ONE,
-        "call_panicking_and_set",
-        &(CROSSOVER_TWO, CROSSOVER_TO_SET),
+        "check_consistent_state_on_errors",
+        &(
+            CROSSOVER_TWO,
+            CROSSOVER_TO_SET,
+            CROSSOVER_TO_SET_FORWARD,
+            CROSSOVER_TO_SET_BACK,
+        ),
     )?;
 
-    assert!(
-        state_is_ok,
-        "The state should be unchanged in the panicking call's ray"
-    );
     assert_eq!(
         session.query::<_, i32>(CROSSOVER_ONE, "crossover", &())?,
         CROSSOVER_TO_SET,
-        "The state should be properly set even after a call panics"
+        "The crossover should still be set even though the other contract panicked"
     );
 
     Ok(())

--- a/piecrust/tests/crossover.rs
+++ b/piecrust/tests/crossover.rs
@@ -4,7 +4,20 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, Error, RawTransaction, VM};
+use piecrust::{module_bytecode, Error, VM};
+use piecrust_uplink::ModuleId;
+
+const CROSSOVER_ONE: ModuleId = {
+    let mut bytes = [0; 32];
+    bytes[0] = 0x01;
+    ModuleId::from_bytes(bytes)
+};
+
+const CROSSOVER_TWO: ModuleId = {
+    let mut bytes = [0; 32];
+    bytes[0] = 0x02;
+    ModuleId::from_bytes(bytes)
+};
 
 #[test]
 fn crossover() -> Result<(), Error> {
@@ -12,36 +25,26 @@ fn crossover() -> Result<(), Error> {
 
     let mut session = vm.genesis_session();
 
-    let contract_id = session.deploy(module_bytecode!("crossover"))?;
+    session.deploy_with_id(CROSSOVER_ONE, module_bytecode!("crossover"))?;
+    session.deploy_with_id(CROSSOVER_TWO, module_bytecode!("crossover"))?;
 
-    // Check that initial crossover value is 7, as hardcoded in the module
-    assert_eq!(7, session.query::<_, i32>(contract_id, "crossover", &())?);
+    const CROSSOVER_TO_SET: i32 = 10;
 
-    // Update crossover, the result is the old value
-    let res = session.transact::<_, i32>(contract_id, "set_crossover", &9)?;
-    assert_eq!(res, 7);
-    assert_eq!(9, session.query::<_, i32>(contract_id, "crossover", &())?);
-
-    // Test self_call_test_a
-    let res =
-        session.transact::<_, i32>(contract_id, "self_call_test_a", &10)?;
-    assert_eq!(res, 9);
-    assert_eq!(10, session.query::<_, i32>(contract_id, "crossover", &())?);
-
-    // Test update_and_panic
-    let result =
-        session.transact::<_, ()>(contract_id, "update_and_panic", &11);
-    assert!(result.is_err());
-    assert_eq!(10, session.query::<_, i32>(contract_id, "crossover", &())?);
-
-    // Test set_crossover as RawTransaction
-    let raw = RawTransaction::new("set_crossover", 12);
-    session.transact::<_, ()>(
-        contract_id,
-        "self_call_test_b",
-        &(contract_id, raw),
+    let state_is_ok: bool = session.transact(
+        CROSSOVER_ONE,
+        "call_panicking_and_set",
+        &(CROSSOVER_TWO, CROSSOVER_TO_SET),
     )?;
-    assert_eq!(12, session.query::<_, i32>(contract_id, "crossover", &())?);
+
+    assert!(
+        state_is_ok,
+        "The state should be unchanged in the panicking call's ray"
+    );
+    assert_eq!(
+        session.query::<_, i32>(CROSSOVER_ONE, "crossover", &())?,
+        CROSSOVER_TO_SET,
+        "The state should be properly set even after a call panics"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Each call, be it a transaction or a query, is now atomic - meaning it
will not change the state if it fails. This is also true for every
inter-contract call performed during said call.
    
This is achieved by a re-execution strategy. Since we have no way of
partially rolling back changes in memory, each failing call - and
inter-contract for that matter - will trigger a re-execution of all
historic calls in a session until said failure occurs. The failure is
then skipped, communicated to the caller, and execution proceeds until
the next error - if so the procedure is gone through again - or until it
succeeds.
    
Resolves #155
Resolves #156