### PR TITLE
Add some documentation to `piecrust`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@ WASM virtual machine handling Dusk's smart contracts.
 ## Usage
 
 ```rust
-use piecrust::{Error, VM};
+use piecrust::VM;
+let mut vm = VM::ephemeral().unwrap();
 
-let bytecode = // load module bytecode ;
+let bytecode = /*load bytecode*/;
 
-let mut vm = VM::ephemeral()?;
-let module_id = vm.deploy(bytecode)?;
+let mut session = vm.genesis_session();
+let contract_id = session.deploy(bytecode).unwrap();
 
-let mut session = vm.session();
-let result = session.transact::<i16, i32>(module_id, "function_name", &0x11)?;
+let result = session.transact::<i16, i32>(contract_id, "function_name", &0x11)?;
 
 // use result
 ```

--- a/piecrust/src/error.rs
+++ b/piecrust/src/error.rs
@@ -19,6 +19,7 @@ pub type Compo = CompositeSerializerError<
     std::convert::Infallible,
 >;
 
+/// The error returned by the piecrust VM.
 #[derive(Error, Debug, Clone)]
 pub enum Error {
     #[error(transparent)]

--- a/piecrust/src/error.rs
+++ b/piecrust/src/error.rs
@@ -19,7 +19,7 @@ pub type Compo = CompositeSerializerError<
     std::convert::Infallible,
 >;
 
-/// The error returned by the piecrust VM.
+/// The error type returned by the piecrust VM.
 #[derive(Error, Debug, Clone)]
 pub enum Error {
     #[error(transparent)]

--- a/piecrust/src/session.rs
+++ b/piecrust/src/session.rs
@@ -41,7 +41,7 @@ const MAX_META_SIZE: usize = 65_536;
 unsafe impl Send for Session {}
 unsafe impl Sync for Session {}
 
-/// A running modification to a state.
+/// A running mutation to a state.
 ///
 /// `Session`s are spawned using a [`VM`] instance, and can be [`queried`] or
 /// [`transacted`] with to modify their state. A sequence of these calls may
@@ -103,7 +103,7 @@ impl Session {
     }
 
     /// Deploy a module, returning its [`ModuleId`]. The ID is computed using a
-    /// `blake3` hash of the bytecode.
+    /// `blake3` hash of the `bytecode`.
     ///
     /// If one needs to specify the ID, [`deploy_with_id`] is available.
     ///
@@ -246,10 +246,10 @@ impl Session {
         Ok(ret)
     }
 
-    /// Return the state root of the current state of the modules.
+    /// Return the state root of the current state of the session.
     ///
-    /// The state root is a merkle root of the tree whose leaves are the state
-    /// of each module, ordered by their module ID.
+    /// The state root is the root of a merkle tree whose leaves are the hashes
+    /// of the state of of each module, ordered by their module ID.
     ///
     /// It also doubles as the ID of a commit - the commit root.
     pub fn root(&self) -> [u8; 32] {

--- a/piecrust/src/session.rs
+++ b/piecrust/src/session.rs
@@ -41,6 +41,21 @@ const MAX_META_SIZE: usize = 65_536;
 unsafe impl Send for Session {}
 unsafe impl Sync for Session {}
 
+/// A running modification to a state.
+///
+/// `Session`s are spawned using a [`VM`] instance, and can be [`queried`] or
+/// [`transacted`] with to modify their state. A sequence of these calls may
+/// then be [`commit`]ed to, or discarded by simply allowing the session to
+/// drop.
+///
+/// New modules are to be `deploy`ed in the context of a session. Metadata
+/// queryable by modules can be set using [`set_meta`].
+///
+/// [`VM`]: crate::VM
+/// [`queried`]: Session::query
+/// [`transacted`]: Session::transact
+/// [`commit`]: Session::commit
+/// [`set_meta`]: Session::set_meta
 pub struct Session {
     call_stack: CallStack,
     debug: Vec<String>,
@@ -87,11 +102,12 @@ impl Session {
         }
     }
 
-    /// Deploy a module, returning its `ModuleId`. The ID is computed using a
+    /// Deploy a module, returning its [`ModuleId`]. The ID is computed using a
     /// `blake3` hash of the bytecode.
     ///
     /// If one needs to specify the ID, [`deploy_with_id`] is available.
     ///
+    /// [`ModuleId`]: ModuleId
     /// [`deploy_with_id`]: `Session::deploy_with_id`
     pub fn deploy(&mut self, bytecode: &[u8]) -> Result<ModuleId, Error> {
         let module_id = self
@@ -107,7 +123,7 @@ impl Session {
         Ok(module_id)
     }
 
-    /// Deploy a module with the given ID.
+    /// Deploy a module with the given `id`.
     ///
     /// If one would like to *not* specify the `ModuleId`, [`deploy`] is
     /// available.
@@ -115,21 +131,37 @@ impl Session {
     /// [`deploy`]: `Session::deploy`
     pub fn deploy_with_id(
         &mut self,
-        module_id: ModuleId,
+        id: ModuleId,
         bytecode: &[u8],
     ) -> Result<(), Error> {
         self.module_session
-            .deploy_with_id(module_id, bytecode)
+            .deploy_with_id(id, bytecode)
             .map_err(|err| PersistenceError(Arc::new(err)))?;
 
         self.call_history.push(From::from(Deploy {
-            module_id,
+            module_id: id,
             bytecode: bytecode.to_vec(),
         }));
 
         Ok(())
     }
 
+    /// Execute a query on the current state of this session.
+    ///
+    /// Calls are atomic, meaning that on failure their execution doesn't modify
+    /// the state. They are also metered, and will execute with the point limit
+    /// defined in [`set_point_limit`].
+    ///
+    /// To know how many points a call spent after execution use the [`spent`]
+    /// function.
+    ///
+    /// # Errors
+    /// The call may error during execution for a wide array of reasons, the
+    /// most common ones being running against the point limit and a module
+    /// panic.
+    ///
+    /// [`set_point_limit`]: Session::set_point_limit
+    /// [`spent`]: Session::spent
     pub fn query<Arg, Ret>(
         &mut self,
         module: ModuleId,
@@ -164,6 +196,22 @@ impl Session {
         Ok(ret)
     }
 
+    /// Execute a transaction on the current state of this session.
+    ///
+    /// Calls are atomic, meaning that on failure their execution doesn't modify
+    /// the state. They are also metered, and will execute with the point limit
+    /// defined in [`set_point_limit`].
+    ///
+    /// To know how many points a call spent after execution use the [`spent`]
+    /// function.
+    ///
+    /// # Errors
+    /// The call may error during execution for a wide array of reasons, the
+    /// most common ones being running against the point limit and a module
+    /// panic.
+    ///
+    /// [`set_point_limit`]: Session::set_point_limit
+    /// [`spent`]: Session::spent
     pub fn transact<Arg, Ret>(
         &mut self,
         module: ModuleId,
@@ -198,6 +246,12 @@ impl Session {
         Ok(ret)
     }
 
+    /// Return the state root of the current state of the modules.
+    ///
+    /// The state root is a merkle root of the tree whose leaves are the state
+    /// of each module, ordered by their module ID.
+    ///
+    /// It also doubles as the ID of a commit - the commit root.
     pub fn root(&self) -> [u8; 32] {
         self.module_session.root()
     }
@@ -231,11 +285,22 @@ impl Session {
         self.host_queries.call(name, buf, arg_len)
     }
 
-    /// Sets the point limit for the next call to `query` or `transact`.
+    /// Sets the point limit for the next call to [`query`] or [`transact`].
+    ///
+    /// [`query`]: Session::query
+    /// [`transact`]: Session::transact
     pub fn set_point_limit(&mut self, limit: u64) {
         self.limit = limit
     }
 
+    /// Returns the number of points spent by the last call to [`query`] or
+    /// [`transact`].
+    ///
+    /// If neither have been called for the duration of the session, it will
+    /// return 0.
+    ///
+    /// [`query`]: Session::query
+    /// [`transact`]: Session::transact
     pub fn spent(&self) -> u64 {
         self.spent
     }
@@ -274,6 +339,8 @@ impl Session {
         self.call_stack.pop();
     }
 
+    /// Commits the given session to disk, consuming the session and returning
+    /// its state root.
     pub fn commit(self) -> Result<[u8; 32], Error> {
         self.module_session
             .commit()
@@ -295,10 +362,15 @@ impl Session {
         c(&self.debug)
     }
 
+    /// Returns the value of a metadata item previously set using [`set_meta`].
+    ///
+    /// [`set_meta`]: Session::set_meta
     pub fn meta(&self, name: &str) -> Option<Vec<u8>> {
         self.data.get(name)
     }
 
+    /// Sets a metadata item with the given `name` and `value`. These pieces of
+    /// data are then made available to modules for querying.
     pub fn set_meta<S, V>(&mut self, name: S, value: V)
     where
         S: Into<Cow<'static, str>>,

--- a/piecrust/src/store.rs
+++ b/piecrust/src/store.rs
@@ -63,8 +63,12 @@ impl ModuleStore {
         let commits = read_all_commits(root_dir)?;
 
         let loop_root_dir = root_dir.to_path_buf();
-        let sync_loop =
-            thread::spawn(|| sync_loop(loop_root_dir, commits, calls));
+
+        // The thread is given a name to allow for easily identifying it while
+        // debugging.
+        let sync_loop = thread::Builder::new()
+            .name(String::from("PiecrustSync"))
+            .spawn(|| sync_loop(loop_root_dir, commits, calls))?;
 
         Ok(Self {
             sync_loop,

--- a/piecrust/src/vm.rs
+++ b/piecrust/src/vm.rs
@@ -17,19 +17,46 @@ use crate::session::Session;
 use crate::store::ModuleStore;
 use crate::Error::{self, PersistenceError};
 
+/// A handle to the piecrust virtual machine.
+///
+/// It is instantiated using [`new`] or [`ephemeral`], and can be used to spawn
+/// multiple [`Session`]s using either [`session`] or [`genesis_session`].
+///
+/// These sessions are synchronized with the help of a sync loop. [`Deletions`]
+/// and [`squashes`] are assured to not delete any commits used as a base for
+/// sessions until these are dropped. A handle to this loop is available at
+/// [`sync_thread`].
+///
+/// Users are encouraged to instantiate a `VM` once during the lifetime of their
+/// program and spawn sessions as needed.
+///
+/// [`new`]: VM::new
+/// [`ephemeral`]: VM::ephemeral
+/// [`Session`]: Session
+/// [`session`]: VM::session
+/// [`genesis_session`]: VM::genesis_session
+/// [`Deletions`]: VM::delete_commit
+/// [`squashes`]: VM::squash_commit
+/// [`sync_thread`]: VM::sync_thread
 pub struct VM {
     host_queries: HostQueries,
     store: ModuleStore,
 }
 
 impl VM {
-    /// Creates a new virtual machine, reading the given directory for existing
-    /// commits and bytecode.
-    pub fn new<P: AsRef<Path>>(dir: P) -> Result<Self, Error>
+    /// Creates a new `VM`, reading the given `dir`ectory for existing commits
+    /// and bytecode.
+    ///
+    /// The directory will be used to save any future session commits made by
+    /// this `VM` instance.
+    ///
+    /// # Errors
+    /// If the directory contains unparseable or inconsistent data.
+    pub fn new<P: AsRef<Path>>(root_dir: P) -> Result<Self, Error>
     where
         P: Into<PathBuf>,
     {
-        let store = ModuleStore::new(dir)
+        let store = ModuleStore::new(root_dir)
             .map_err(|err| PersistenceError(Arc::new(err)))?;
         Ok(Self {
             host_queries: HostQueries::default(),
@@ -37,7 +64,13 @@ impl VM {
         })
     }
 
-    /// Creates a new virtual machine using a temporary directory.
+    /// Creates a new `VM` using a new temporary directory.
+    ///
+    /// Any session commits made by this machine should be considered discarded
+    /// once this `VM` instance drops.
+    ///
+    /// # Errors
+    /// If creating a temporary directory fails.
     pub fn ephemeral() -> Result<Self, Error> {
         let tmp = tempdir().map_err(|err| PersistenceError(Arc::new(err)))?;
         let tmp = tmp.path().to_path_buf();
@@ -51,7 +84,12 @@ impl VM {
         })
     }
 
-    /// Registers a [`HostQuery`] with the given `name`.
+    /// Registers a [host `query`] with the given `name`.
+    ///
+    /// The query will be available to any session spawned *after* this was
+    /// called.
+    ///
+    /// [host `query`]: HostQuery
     pub fn register_host_query<Q, S>(&mut self, name: S, query: Q)
     where
         Q: 'static + HostQuery,
@@ -60,6 +98,17 @@ impl VM {
         self.host_queries.insert(name, query);
     }
 
+    /// Spawn a [`Session`] with the given commit as the `base`.
+    ///
+    /// Sessions spawned with a commit as a base are running modifications to
+    /// said commit. For sessions with no commit as base use
+    /// [`genesis_session`].
+    ///
+    /// # Errors
+    /// If the given base commit does not exist.
+    ///
+    /// [`Session`]: Session
+    /// [`genesis_session`]: VM::genesis_session
     pub fn session(&self, base: [u8; 32]) -> Result<Session, Error> {
         let module_session = self
             .store
@@ -68,21 +117,27 @@ impl VM {
         Ok(Session::new(module_session, self.host_queries.clone()))
     }
 
+    /// Spawn a [`Session`] with no commit as a base.
+    ///
+    /// Genesis sessions are used for initial state deployment. For sessions
+    /// based on previous commits use [`session`].
+    ///
+    /// [`Session`]: Session
+    /// [`session`]: VM::session
     pub fn genesis_session(&self) -> Session {
         let module_session = self.store.genesis_session();
         Session::new(module_session, self.host_queries.clone())
     }
 
-    /// Return all the existing commits on disk.
+    /// Return all existing commits.
     pub fn commits(&self) -> Vec<[u8; 32]> {
         self.store.commits()
     }
 
-    /// Remove the diff files from a commit by applying them to the base memory,
-    /// and writing it back to disk.
+    /// Remove the diff files from a commit by applying them to the base
+    /// memories, and writing them back to disk.
     ///
     /// # Errors
-    ///
     /// If this function fails, it may be due to any number of reasons:
     ///
     /// - [`remove_file`] may fail
@@ -108,11 +163,18 @@ impl VM {
     }
 
     /// Return the root directory of the virtual machine.
+    ///
+    /// This is either the directory passed in by using [`new`], or the
+    /// temporary directory created using [`ephemeral`].
+    ///
+    /// [`new`]: VM::new
+    /// [`ephemeral`]: VM::ephemeral
     pub fn root_dir(&self) -> &Path {
         self.store.root_dir()
     }
 
-    pub fn sync_loop_thread(&self) -> &thread::Thread {
+    /// Returns a reference to the synchronization thread.
+    pub fn sync_thread(&self) -> &thread::Thread {
         self.store.sync_loop()
     }
 }
@@ -144,9 +206,10 @@ impl HostQueries {
 
 /// A query executable on the host.
 ///
-/// The buffer containing the argument the module used to call the query
-/// together with its length are passed as arguments to the function, and should
-/// be processed first. Once this is done, the implementor should emplace the
-/// return of the query in the same buffer, and return its length.
+/// The buffer containing the argument the module used to call the query,
+/// together with the argument's length, are passed as arguments to the
+/// function, and should be processed first. Once this is done, the implementor
+/// should emplace the return of the query in the same buffer, and return the
+/// length written.
 pub trait HostQuery: Send + Sync + Fn(&mut [u8], u32) -> u32 {}
 impl<F> HostQuery for F where F: Send + Sync + Fn(&mut [u8], u32) -> u32 {}

--- a/piecrust/src/vm.rs
+++ b/piecrust/src/vm.rs
@@ -146,8 +146,8 @@ impl VM {
     /// Failing may result in a corrupted commit, and the user is encouraged to
     /// call [`delete_commit`].
     ///
-    /// [`remove_file`]: fs::remove_file
-    /// [`write`]: fs::write
+    /// [`remove_file`]: std::fs::remove_file
+    /// [`write`]: std::fs::write
     /// [`delete_commit`]: VM::delete_commit
     pub fn squash_commit(&self, root: [u8; 32]) -> Result<(), Error> {
         self.store


### PR DESCRIPTION
Adds some more comprehensive documentation to the `piecrust` crate. We ensure that at least the exposed API of the crate is covered.

See also: #103