### PR TITLE
Made meta data access option-based, never panicking

### DIFF
--- a/modules/everest/src/lib.rs
+++ b/modules/everest/src/lib.rs
@@ -24,8 +24,8 @@ static mut STATE: State<Height> = State::new(Height);
 
 impl Height {
     /// Query the host for the current block height
-    pub fn get_height(&self) -> u64 {
-        uplink::host_data::<u64>("height")
+    pub fn get_height(&self) -> Option<u64> {
+        uplink::meta_data::<u64>("height")
     }
 }
 

--- a/piecrust-uplink/src/lib.rs
+++ b/piecrust-uplink/src/lib.rs
@@ -15,7 +15,7 @@ pub use snap::snap;
 
 mod state;
 pub use state::{
-    caller, height, host_data, host_query, limit, query, query_raw, spent,
+    caller, height, host_query, limit, meta_data, query, query_raw, spent,
     ModuleError, State,
 };
 

--- a/piecrust-uplink/src/state.rs
+++ b/piecrust-uplink/src/state.rs
@@ -233,7 +233,7 @@ pub fn query_raw(
 
 /// Returns data made available by the host under the given name. The type `D`
 /// must be correctly specified, otherwise undefined behavior will occur.
-pub fn host_data<D>(name: &str) -> D
+pub fn meta_data<D>(name: &str) -> Option<D>
 where
     D: Archive,
     D::Archived: Deserialize<D, Infallible>,
@@ -244,12 +244,13 @@ where
     let name_len = name_slice.len() as u32;
 
     unsafe {
-        let arg_pos = ext::hd(name, name_len) as usize;
-
-        with_arg_buf(|buf| {
-            let ret = archived_root::<D>(&buf[..arg_pos]);
-            ret.deserialize(&mut Infallible).expect("Infallible")
-        })
+        match ext::hd(name, name_len) as usize {
+            0 => None,
+            arg_pos => Some(with_arg_buf(|buf| {
+                let ret = archived_root::<D>(&buf[..arg_pos]);
+                ret.deserialize(&mut Infallible).expect("Infallible")
+            })),
+        }
     }
 }
 

--- a/piecrust/src/imports.rs
+++ b/piecrust/src/imports.rs
@@ -234,13 +234,16 @@ fn hd(mut fenv: FunctionEnvMut<Env>, name_ofs: i32, name_len: u32) -> u32 {
             .to_owned()
     });
 
-    let data = env.meta(&name).expect("the metadata should exist");
+    match env.meta(&name) {
+        Some(data) => {
+            instance.with_arg_buffer(|buf| {
+                buf[..data.len()].copy_from_slice(&data);
+            });
 
-    instance.with_arg_buffer(|buf| {
-        buf[..data.len()].copy_from_slice(&data);
-    });
-
-    data.len() as u32
+            data.len() as u32
+        }
+        _ => 0u32,
+    }
 }
 
 fn emit(mut fenv: FunctionEnvMut<Env>, arg_len: u32) {

--- a/piecrust/tests/everest.rs
+++ b/piecrust/tests/everest.rs
@@ -16,9 +16,18 @@ pub fn height() -> Result<(), Error> {
 
     for h in 0u64..1024 {
         session.set_meta("height", h);
-        let height: u64 = session.transact(id, "get_height", &())?;
-        assert_eq!(height, h);
+        let height: Option<u64> = session.transact(id, "get_height", &())?;
+        assert_eq!(height.unwrap(), h);
     }
 
+    Ok(())
+}
+#[test]
+pub fn meta_data_optionality() -> Result<(), Error> {
+    let vm = VM::ephemeral()?;
+    let mut session = vm.genesis_session();
+    let id = session.deploy(module_bytecode!("everest"))?;
+    let height: Option<u64> = session.transact(id, "get_height", &())?;
+    assert!(height.is_none());
     Ok(())
 }


### PR DESCRIPTION
Host data has been renamed o meta data, access to which
is now optional, never panicking.

Described in issue #158
