### PR TITLE
Metadata Owner 158

### DIFF
--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "fallible_counter",    
     "fibonacci",
     "host",
+    "metadata",
     "micro",
     "crossover",
     "spender",

--- a/modules/metadata/Cargo.toml
+++ b/modules/metadata/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "metadata"
+version = "0.1.0"
+authors = [
+    "Milosz Muszynski <milosz@dusk.network>",
+]
+edition = "2021"
+
+license = "MPL-2.0"
+
+[dependencies]
+piecrust-uplink = { path = "../../piecrust-uplink", default-features = false, features = ["wee_alloc"] }
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/modules/metadata/src/lib.rs
+++ b/modules/metadata/src/lib.rs
@@ -1,0 +1,37 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+//! Module that provides and example use of the metadata.
+
+#![feature(arbitrary_self_types)]
+#![no_std]
+
+use piecrust_uplink as uplink;
+use uplink::{ModuleId, State};
+
+/// Struct that describes the (empty) state of the Metadata module
+pub struct Metadata;
+
+
+/// Module ID, initialized by the host when the module is deployed
+#[no_mangle]
+static SELF_ID: ModuleId = ModuleId::uninitialized();
+
+/// State of the Metadata module
+static mut STATE: State<Metadata> = State::new(Metadata {});
+
+impl Metadata {
+    /// Read the value of the metadata module state
+    pub fn read_owner(&self) -> [u8; 32] {
+        uplink::owner()
+    }
+}
+
+/// Expose `Metadata::read_owner()` to the host
+#[no_mangle]
+unsafe fn read_owner(arg_len: u32) -> u32 {
+    uplink::wrap_query(arg_len, |_: ()| STATE.read_owner())
+}

--- a/piecrust-uplink/src/lib.rs
+++ b/piecrust-uplink/src/lib.rs
@@ -37,5 +37,7 @@ pub const SCRATCH_BUF_BYTES: usize = 64;
 /// The size of the argument buffer in bytes
 pub const ARGBUF_LEN: usize = 64 * 1024;
 
+/// The size of metadata in bytes
+pub const METADATA_LEN: usize = 1;
 #[cfg(not(feature = "std"))]
 mod handlers;

--- a/piecrust-uplink/src/lib.rs
+++ b/piecrust-uplink/src/lib.rs
@@ -37,7 +37,5 @@ pub const SCRATCH_BUF_BYTES: usize = 64;
 /// The size of the argument buffer in bytes
 pub const ARGBUF_LEN: usize = 64 * 1024;
 
-/// The size of metadata in bytes
-pub const METADATA_LEN: usize = 1;
 #[cfg(not(feature = "std"))]
 mod handlers;

--- a/piecrust-uplink/src/lib.rs
+++ b/piecrust-uplink/src/lib.rs
@@ -15,8 +15,8 @@ pub use snap::snap;
 
 mod state;
 pub use state::{
-    caller, height, host_query, limit, meta_data, query, query_raw, spent,
-    ModuleError, State,
+    caller, height, host_query, limit, meta_data, owner, query, query_raw,
+    spent, ModuleError, State,
 };
 
 mod helpers;

--- a/piecrust-uplink/src/state.rs
+++ b/piecrust-uplink/src/state.rs
@@ -38,6 +38,11 @@ mod arg_buf {
     }
 }
 
+mod metadata {
+    use crate::METADATA_LEN;
+    #[no_mangle]
+    static mut M: [u8; METADATA_LEN] = [0u8; METADATA_LEN];
+}
 pub(crate) use arg_buf::with_arg_buf;
 
 mod ext {

--- a/piecrust-uplink/src/state.rs
+++ b/piecrust-uplink/src/state.rs
@@ -38,11 +38,6 @@ mod arg_buf {
     }
 }
 
-mod metadata {
-    use crate::METADATA_LEN;
-    #[no_mangle]
-    static mut M: [u8; METADATA_LEN] = [0u8; METADATA_LEN];
-}
 pub(crate) use arg_buf::with_arg_buf;
 
 mod ext {

--- a/piecrust-uplink/src/state.rs
+++ b/piecrust-uplink/src/state.rs
@@ -62,6 +62,7 @@ mod ext {
         pub(crate) fn emit(arg_len: u32);
         pub(crate) fn limit() -> u64;
         pub(crate) fn spent() -> u64;
+        pub(crate) fn owner() -> i32;
     }
 }
 
@@ -261,6 +262,15 @@ pub fn height() -> u64 {
         let ret = unsafe {
             archived_root::<u64>(&buf[..core::mem::size_of::<Archived<u64>>()])
         };
+        ret.deserialize(&mut Infallible).expect("Infallible")
+    })
+}
+
+/// Return the current owner.
+pub fn owner() -> [u8; 32] {
+    unsafe { ext::owner() };
+    with_arg_buf(|buf| {
+        let ret = unsafe { archived_root::<[u8; 32]>(&buf[..32]) };
         ret.deserialize(&mut Infallible).expect("Infallible")
     })
 }

--- a/piecrust-uplink/src/types.rs
+++ b/piecrust-uplink/src/types.rs
@@ -218,6 +218,22 @@ impl RawResult {
     }
 }
 
+#[derive(Archive, Serialize, Deserialize)]
+#[archive_attr(derive(CheckBytes))]
+pub struct ModuleMetadata {
+    owner: [u8; 32],
+}
+
+impl ModuleMetadata {
+    pub fn new(owner: [u8; 32]) -> Self {
+        Self { owner }
+    }
+
+    pub fn owner(&self) -> &[u8; 32] {
+        &self.owner
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/piecrust/src/imports.rs
+++ b/piecrust/src/imports.rs
@@ -10,7 +10,6 @@ use crate::Error;
 use piecrust_uplink::{ModuleError, ModuleId, ARGBUF_LEN};
 
 use crate::instance::Env;
-use crate::store::Metadata;
 
 const POINT_PASS_PCT: u64 = 93;
 
@@ -31,7 +30,7 @@ impl DefaultImports {
                 "emit" => Function::new_typed_with_env(store, &fenv, emit),
                 "limit" => Function::new_typed_with_env(store, &fenv, limit),
                 "spent" => Function::new_typed_with_env(store, &fenv, spent),
-                "owner" => Function::new_typed_with_env(store, &fenv, owner),
+                "metadata" => Function::new_typed_with_env(store, &fenv, metadata),
             }
         }
     }
@@ -285,12 +284,12 @@ fn spent(fenv: FunctionEnvMut<Env>) -> u64 {
     limit - remaining
 }
 
-fn owner(fenv: FunctionEnvMut<Env>) -> i32 {
+fn metadata(fenv: FunctionEnvMut<Env>) -> u32 {
     let env = fenv.data();
     let self_id = env.self_module_id();
     let slice = env.metadata(self_id).expect("metadata should exist");
-    assert_eq!(slice.len(), 32);
+    let len = slice.len();
     env.self_instance()
-        .with_arg_buffer(|arg| arg[..32].copy_from_slice(slice));
-    32
+        .with_arg_buffer(|arg| arg[..len].copy_from_slice(slice));
+    len as u32
 }

--- a/piecrust/src/imports.rs
+++ b/piecrust/src/imports.rs
@@ -10,6 +10,7 @@ use crate::Error;
 use piecrust_uplink::{ModuleError, ModuleId, ARGBUF_LEN};
 
 use crate::instance::Env;
+use crate::store::Metadata;
 
 const POINT_PASS_PCT: u64 = 93;
 
@@ -30,6 +31,7 @@ impl DefaultImports {
                 "emit" => Function::new_typed_with_env(store, &fenv, emit),
                 "limit" => Function::new_typed_with_env(store, &fenv, limit),
                 "spent" => Function::new_typed_with_env(store, &fenv, spent),
+                "owner" => Function::new_typed_with_env(store, &fenv, owner),
             }
         }
     }
@@ -281,4 +283,14 @@ fn spent(fenv: FunctionEnvMut<Env>) -> u64 {
         .expect("there should be remaining points");
 
     limit - remaining
+}
+
+fn owner(fenv: FunctionEnvMut<Env>) -> i32 {
+    let env = fenv.data();
+    let self_id = env.self_module_id();
+    let slice = env.metadata(self_id).expect("metadata should exist");
+    assert_eq!(slice.len(), 32);
+    env.self_instance()
+        .with_arg_buffer(|arg| arg[..32].copy_from_slice(slice));
+    32
 }

--- a/piecrust/src/instance.rs
+++ b/piecrust/src/instance.rs
@@ -91,6 +91,10 @@ impl Env {
         let event = Event::new(self.self_id, data);
         self.session.push_event(event);
     }
+
+    pub fn self_module_id(&self) -> &ModuleId {
+        &self.self_id
+    }
 }
 
 /// Convenience methods for dealing with our custom store

--- a/piecrust/src/instance.rs
+++ b/piecrust/src/instance.rs
@@ -37,6 +37,7 @@ pub struct WrappedInstance {
     #[allow(unused)]
     heap_base: usize,
     store: wasmer::Store,
+    meta_ofs: usize,
 }
 
 pub(crate) struct Env {
@@ -177,6 +178,10 @@ impl WrappedInstance {
                 _ => todo!("Missing `SELF_ID` export"),
             };
 
+        let meta_ofs = match instance.exports.get_global("M")?.get(&mut store) {
+            wasmer::Value::I32(i) => i as usize,
+            _ => todo!("Missing `M` Metadata export"),
+        };
         // write self id into memory.
         let mut memory_guard = memory.write();
         let bytes = memory_guard.as_bytes_mut();
@@ -188,6 +193,7 @@ impl WrappedInstance {
             instance,
             arg_buf_ofs,
             heap_base,
+            meta_ofs,
         };
 
         Ok(wrapped)
@@ -249,6 +255,18 @@ impl WrappedInstance {
         })
     }
 
+    pub(crate) fn with_meta_buffer<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(&mut [u8]) -> R,
+    {
+        self.with_memory_mut(|memory_bytes| {
+            let a = self.meta_ofs;
+            let b = uplink::METADATA_LEN;
+            let begin = &mut memory_bytes[a..];
+            let trimmed = &mut begin[..b];
+            f(trimmed)
+        })
+    }
     pub(crate) fn write_bytes_to_arg_buffer(&self, buf: &[u8]) -> u32 {
         self.with_arg_buffer(|arg_buffer| {
             arg_buffer[..buf.len()].copy_from_slice(buf);

--- a/piecrust/src/session.rs
+++ b/piecrust/src/session.rs
@@ -63,7 +63,7 @@ pub struct Session {
     instance_map: BTreeMap<ModuleId, (*mut WrappedInstance, u64)>,
     debug: Vec<String>,
     events: Vec<Event>,
-    data: Metadata,
+    data: SessionMetadata,
 
     module_session: ModuleSession,
     host_queries: HostQueries,
@@ -92,7 +92,7 @@ impl Session {
             instance_map: BTreeMap::new(),
             debug: vec![],
             events: vec![],
-            data: Metadata::new(),
+            data: SessionMetadata::new(),
             module_session,
             host_queries,
             limit: DEFAULT_LIMIT,
@@ -172,8 +172,10 @@ impl Session {
         }
 
         let wrapped_module = WrappedModule::new(bytecode, None::<Objectcode>)?;
+        // todo: replace this mock with real metadata
+        let mock_metadata = "abc".as_bytes();
         self.module_session
-            .deploy_with_id(id, bytecode, wrapped_module.as_bytes())
+            .deploy_with_id(id, bytecode, wrapped_module.as_bytes(), mock_metadata)
             .map_err(|err| PersistenceError(Arc::new(err)))?;
 
         self.create_instance(id)?;
@@ -788,11 +790,11 @@ struct Call {
 }
 
 #[derive(Debug)]
-pub struct Metadata {
+pub struct SessionMetadata {
     data: BTreeMap<Cow<'static, str>, Vec<u8>>,
 }
 
-impl Metadata {
+impl SessionMetadata {
     fn new() -> Self {
         Self {
             data: BTreeMap::new(),

--- a/piecrust/src/session.rs
+++ b/piecrust/src/session.rs
@@ -172,10 +172,17 @@ impl Session {
         }
 
         let wrapped_module = WrappedModule::new(bytecode, None::<Objectcode>)?;
-        // todo: replace this mock with real metadata
-        let mock_metadata = "abc".as_bytes();
+        /* todo: replace this mock with real metadata
+           we are not serializing the metadata here, just taking it
+           literally, still, it deserializes correctly for [u8;32] */
+        const OWNER_MOCK_VALUE: [u8; 32] = [3u8; 32];
         self.module_session
-            .deploy_with_id(id, bytecode, wrapped_module.as_bytes(), mock_metadata)
+            .deploy_with_id(
+                id,
+                bytecode,
+                wrapped_module.as_bytes(),
+                OWNER_MOCK_VALUE.as_slice(),
+            )
             .map_err(|err| PersistenceError(Arc::new(err)))?;
 
         self.create_instance(id)?;
@@ -746,6 +753,10 @@ impl Session {
         self.pop_callstack();
 
         Ok(ret)
+    }
+
+    pub fn metadata(&self, module_id: &ModuleId) -> Option<&[u8]> {
+        self.module_session.metadata(module_id)
     }
 }
 

--- a/piecrust/src/session.rs
+++ b/piecrust/src/session.rs
@@ -406,14 +406,22 @@ impl Session {
         &mut self,
         module_id: ModuleId,
     ) -> Result<WrappedInstance, Error> {
-        let (bytecode, objectcode, memory) = self
+        let store_data = self
             .module_session
             .module(module_id)
             .map_err(|err| PersistenceError(Arc::new(err)))?
             .expect("Module should exist");
 
-        let module = WrappedModule::new(&bytecode, Some(&objectcode))?;
-        let instance = WrappedInstance::new(self, module_id, &module, memory)?;
+        let module = WrappedModule::new(
+            store_data.bytecode(),
+            Some(store_data.objectcode()),
+        )?;
+        let instance = WrappedInstance::new(
+            self,
+            module_id,
+            &module,
+            store_data.memory(),
+        )?;
 
         Ok(instance)
     }

--- a/piecrust/src/store.rs
+++ b/piecrust/src/store.rs
@@ -10,8 +10,8 @@ mod bytecode;
 mod diff;
 mod memory;
 mod mmap;
+mod module_session;
 mod objectcode;
-mod session;
 
 use std::collections::btree_map::Entry::*;
 use std::collections::{BTreeMap, BTreeSet};
@@ -26,9 +26,10 @@ use flate2::Compression;
 pub use bytecode::Bytecode;
 use diff::diff;
 pub use memory::Memory;
+pub use module_session::ModuleSession;
+use module_session::StoreData;
 pub use objectcode::Objectcode;
 use piecrust_uplink::ModuleId;
-pub use session::ModuleSession;
 
 const ROOT_LEN: usize = 32;
 
@@ -286,7 +287,7 @@ pub(crate) struct Commit {
 
 pub(crate) enum Call {
     Commit {
-        modules: BTreeMap<ModuleId, (Bytecode, Objectcode, Memory)>,
+        modules: BTreeMap<ModuleId, StoreData>,
         base: Option<(Root, Commit)>,
         replier: mpsc::SyncSender<io::Result<(Root, Commit)>>,
     },
@@ -467,7 +468,7 @@ fn write_commit<P: AsRef<Path>>(
     root_dir: P,
     commits: &mut BTreeMap<Root, Commit>,
     base: Option<(Root, Commit)>,
-    commit_modules: BTreeMap<ModuleId, (Bytecode, Objectcode, Memory)>,
+    commit_modules: BTreeMap<ModuleId, StoreData>,
 ) -> io::Result<(Root, Commit)> {
     let root_dir = root_dir.as_ref();
 
@@ -506,7 +507,7 @@ fn write_commit_inner<P: AsRef<Path>>(
     commit_dir: P,
     base: Option<(Root, Commit)>,
     modules: BTreeMap<ModuleId, Root>,
-    commit_modules: BTreeMap<ModuleId, (Bytecode, Objectcode, Memory)>,
+    commit_modules: BTreeMap<ModuleId, StoreData>,
 ) -> io::Result<Commit> {
     let root_dir = root_dir.as_ref();
     let commit_dir = commit_dir.as_ref();
@@ -521,7 +522,7 @@ fn write_commit_inner<P: AsRef<Path>>(
 
     match base {
         None => {
-            for (module, (bytecode, objectcode, memory)) in commit_modules {
+            for (module, store_data) in commit_modules {
                 let module_hex = hex::encode(module);
 
                 let bytecode_path = bytecode_dir.join(&module_hex);
@@ -529,9 +530,9 @@ fn write_commit_inner<P: AsRef<Path>>(
                     bytecode_path.with_extension(OBJECTCODE_EXTENSION);
                 let memory_path = memory_dir.join(&module_hex);
 
-                fs::write(bytecode_path, &bytecode)?;
-                fs::write(objectcode_path, &objectcode)?;
-                fs::write(memory_path, &memory.read())?;
+                fs::write(bytecode_path, store_data.bytecode())?;
+                fs::write(objectcode_path, store_data.objectcode())?;
+                fs::write(memory_path, &store_data.memory().read())?;
             }
         }
         Some((base, base_commit)) => {
@@ -572,7 +573,7 @@ fn write_commit_inner<P: AsRef<Path>>(
                 }
             }
 
-            for (module, (bytecode, objectcode, memory)) in commit_modules {
+            for (module, store_data) in commit_modules {
                 let module_hex = hex::encode(module);
 
                 match base_commit.modules.contains_key(&module) {
@@ -593,7 +594,7 @@ fn write_commit_inner<P: AsRef<Path>>(
 
                         diff(
                             &base_memory.read(),
-                            &memory.read(),
+                            &store_data.memory().read(),
                             &mut encoder,
                         )?;
 
@@ -605,9 +606,9 @@ fn write_commit_inner<P: AsRef<Path>>(
                             bytecode_path.with_extension(OBJECTCODE_EXTENSION);
                         let memory_path = memory_dir.join(&module_hex);
 
-                        fs::write(bytecode_path, &bytecode)?;
-                        fs::write(objectcode_path, &objectcode)?;
-                        fs::write(memory_path, memory.read())?;
+                        fs::write(bytecode_path, store_data.bytecode())?;
+                        fs::write(objectcode_path, store_data.objectcode())?;
+                        fs::write(memory_path, store_data.memory().read())?;
                     }
                 }
             }
@@ -680,16 +681,16 @@ fn compute_root<'a, I>(
     modules: I,
 ) -> (Root, BTreeMap<ModuleId, Root>)
 where
-    I: IntoIterator<Item = (&'a ModuleId, &'a (Bytecode, Objectcode, Memory))>,
+    I: IntoIterator<Item = (&'a ModuleId, &'a StoreData)>,
 {
     let iter = modules.into_iter();
 
     let mut leaves_map = BTreeMap::new();
 
     // Compute the hashes of changed memories
-    for (module, (_, _, memory)) in iter {
+    for (module, store_data) in iter {
         let mut hasher = blake3::Hasher::new();
-        hasher.update(&memory.read());
+        hasher.update(&store_data.memory().read());
         leaves_map.insert(*module, Root::from(hasher.finalize()));
     }
 

--- a/piecrust/src/store.rs
+++ b/piecrust/src/store.rs
@@ -9,6 +9,7 @@
 mod bytecode;
 mod diff;
 mod memory;
+mod metadata;
 mod mmap;
 mod module_session;
 mod objectcode;
@@ -26,6 +27,7 @@ use flate2::Compression;
 pub use bytecode::Bytecode;
 use diff::diff;
 pub use memory::Memory;
+pub use metadata::Metadata;
 pub use module_session::ModuleSession;
 use module_session::StoreData;
 pub use objectcode::Objectcode;
@@ -38,6 +40,7 @@ const MEMORY_DIR: &str = "memory";
 const DIFF_EXTENSION: &str = "diff";
 const INDEX_FILE: &str = "index";
 const OBJECTCODE_EXTENSION: &str = ".a";
+const METADATA_EXTENSION: &str = ".m";
 
 type Root = [u8; ROOT_LEN];
 
@@ -528,10 +531,13 @@ fn write_commit_inner<P: AsRef<Path>>(
                 let bytecode_path = bytecode_dir.join(&module_hex);
                 let objectcode_path =
                     bytecode_path.with_extension(OBJECTCODE_EXTENSION);
+                let metadata_path =
+                    bytecode_path.with_extension(METADATA_EXTENSION);
                 let memory_path = memory_dir.join(&module_hex);
 
                 fs::write(bytecode_path, store_data.bytecode())?;
                 fs::write(objectcode_path, store_data.objectcode())?;
+                fs::write(metadata_path, store_data.metadata())?;
                 fs::write(memory_path, &store_data.memory().read())?;
             }
         }
@@ -548,15 +554,20 @@ fn write_commit_inner<P: AsRef<Path>>(
                 let bytecode_path = bytecode_dir.join(&module_hex);
                 let objectcode_path =
                     bytecode_path.with_extension(OBJECTCODE_EXTENSION);
+                let metadata_path =
+                    bytecode_path.with_extension(METADATA_EXTENSION);
                 let memory_path = memory_dir.join(&module_hex);
 
                 let base_bytecode_path = base_bytecode_dir.join(&module_hex);
                 let base_objectcode_path =
                     base_bytecode_path.with_extension(OBJECTCODE_EXTENSION);
+                let base_metadata_path =
+                    base_bytecode_path.with_extension(METADATA_EXTENSION);
                 let base_memory_path = base_memory_dir.join(&module_hex);
 
                 fs::hard_link(base_bytecode_path, bytecode_path)?;
                 fs::hard_link(base_objectcode_path, objectcode_path)?;
+                fs::hard_link(base_metadata_path, metadata_path)?;
                 fs::hard_link(&base_memory_path, &memory_path)?;
 
                 // If there is a diff of this memory in the base module, and it
@@ -604,10 +615,13 @@ fn write_commit_inner<P: AsRef<Path>>(
                         let bytecode_path = bytecode_dir.join(&module_hex);
                         let objectcode_path =
                             bytecode_path.with_extension(OBJECTCODE_EXTENSION);
+                        let metadata_path =
+                            bytecode_path.with_extension(METADATA_EXTENSION);
                         let memory_path = memory_dir.join(&module_hex);
 
                         fs::write(bytecode_path, store_data.bytecode())?;
                         fs::write(objectcode_path, store_data.objectcode())?;
+                        fs::write(metadata_path, store_data.metadata())?;
                         fs::write(memory_path, store_data.memory().read())?;
                     }
                 }

--- a/piecrust/src/store/metadata.rs
+++ b/piecrust/src/store/metadata.rs
@@ -1,0 +1,40 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use std::io;
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::store::mmap::Mmap;
+
+/// WASM object code belonging to a given module.
+#[derive(Debug, Clone)]
+pub struct Metadata {
+    mmap: Arc<Mmap>,
+}
+
+impl Metadata {
+    pub(crate) fn new<B: AsRef<[u8]>>(bytes: B) -> io::Result<Self> {
+        let mmap = Mmap::new(bytes)?;
+
+        Ok(Self {
+            mmap: Arc::new(mmap),
+        })
+    }
+
+    pub(crate) fn from_file<P: AsRef<Path>>(path: P) -> io::Result<Self> {
+        let mmap = Mmap::map(path)?;
+        Ok(Self {
+            mmap: Arc::new(mmap),
+        })
+    }
+}
+
+impl AsRef<[u8]> for Metadata {
+    fn as_ref(&self) -> &[u8] {
+        &self.mmap
+    }
+}

--- a/piecrust/src/store/module_session.rs
+++ b/piecrust/src/store/module_session.rs
@@ -253,7 +253,7 @@ impl ModuleSession {
         Ok(())
     }
 
-    /// todo
+    /// Provides metadata of the module with a given `module_id`.
     pub fn metadata(&self, module_id: &ModuleId) -> Option<&[u8]> {
         self.modules
             .get(module_id)

--- a/piecrust/src/store/module_session.rs
+++ b/piecrust/src/store/module_session.rs
@@ -245,10 +245,19 @@ impl ModuleSession {
         let objectcode = Objectcode::new(objectcode)?;
         let metadata = Metadata::new(metadata)?;
 
-        self.modules
-            .insert(module_id, StoreData::new(bytecode, objectcode, metadata, memory));
+        self.modules.insert(
+            module_id,
+            StoreData::new(bytecode, objectcode, metadata, memory),
+        );
 
         Ok(())
+    }
+
+    /// todo
+    pub fn metadata(&self, module_id: &ModuleId) -> Option<&[u8]> {
+        self.modules
+            .get(module_id)
+            .map(|store_data| store_data.metadata.as_ref())
     }
 }
 

--- a/piecrust/tests/constructor.rs
+++ b/piecrust/tests/constructor.rs
@@ -64,7 +64,7 @@ fn missing_init() -> Result<(), Error> {
     let result = session.deploy::<u8>(module_bytecode!("counter"), Some(&0xab));
     assert!(
         result.is_err(),
-        "deploy_and_init when the 'init' method is not exported should fail with an error"
+        "deploy with data when the 'init' method is not exported should fail with an error"
     );
 
     Ok(())

--- a/piecrust/tests/metadata.rs
+++ b/piecrust/tests/metadata.rs
@@ -8,22 +8,23 @@ use piecrust::{module_bytecode, Error, VM};
 
 #[test]
 fn metadata() -> Result<(), Error> {
+    const EXPECTED_OWNER: [u8; 32] = [3u8; 32];
+
     let vm = VM::ephemeral()?;
 
     let mut session = vm.genesis_session();
 
     let id = session.deploy(module_bytecode!("metadata"), None::<&()>)?;
 
+    // owner should be available after deployment
     let owner = session.query::<(), [u8; 32]>(id, "read_owner", &())?;
-    println!("owner1 = {:x?}", owner);
-    assert_eq!(owner, [3u8; 32]);
+    assert_eq!(owner, EXPECTED_OWNER);
 
-    // metadata should live through across session boundaries
+    // owner should live across session boundaries
     let commit_id = session.commit()?;
     let mut session = vm.session(commit_id)?;
     let owner = session.query::<(), [u8; 32]>(id, "read_owner", &())?;
-    println!("owner2 = {:x?}", owner);
-    assert_eq!(owner, [3u8; 32]);
+    assert_eq!(owner, EXPECTED_OWNER);
 
     Ok(())
 }

--- a/piecrust/tests/metadata.rs
+++ b/piecrust/tests/metadata.rs
@@ -1,0 +1,29 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use piecrust::{module_bytecode, Error, VM};
+
+#[test]
+fn metadata() -> Result<(), Error> {
+    let vm = VM::ephemeral()?;
+
+    let mut session = vm.genesis_session();
+
+    let id = session.deploy(module_bytecode!("metadata"), None::<&()>)?;
+
+    let owner = session.query::<(), [u8; 32]>(id, "read_owner", &())?;
+    println!("owner1 = {:x?}", owner);
+    assert_eq!(owner, [3u8; 32]);
+
+    // metadata should live through across session boundaries
+    let commit_id = session.commit()?;
+    let mut session = vm.session(commit_id)?;
+    let owner = session.query::<(), [u8; 32]>(id, "read_owner", &())?;
+    println!("owner2 = {:x?}", owner);
+    assert_eq!(owner, [3u8; 32]);
+
+    Ok(())
+}


### PR DESCRIPTION
Implements contract ownership.
Metadata for each contract is kept independently from contacts, so that only host access to it.
Ownership API is still to be decided.

Will implement #158 
