### PR TITLE
Structure improvement and data encapsulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ let mut vm = VM::ephemeral().unwrap();
 
 let bytecode = /*load bytecode*/;
 
-let mut session = vm.genesis_session(SessionData::new());
+let mut session = vm.session(SessionData::builder())?;
 let contract_id = session.deploy(bytecode).unwrap();
 
 let result = session.transact::<i16, i32>(contract_id, "function_name", &0x11)?;

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ let mut vm = VM::ephemeral().unwrap();
 
 let bytecode = /*load bytecode*/;
 
-let mut session = vm.genesis_session();
+let mut session = vm.genesis_session(SessionData::new());
 let contract_id = session.deploy(bytecode).unwrap();
 
 let result = session.transact::<i16, i32>(contract_id, "function_name", &0x11)?;

--- a/piecrust-uplink/src/state.rs
+++ b/piecrust-uplink/src/state.rs
@@ -82,7 +82,7 @@ use core::ops::{Deref, DerefMut};
 #[archive_attr(derive(CheckBytes))]
 pub enum ModuleError {
     PANIC,
-    OUT_OF_GAS,
+    OutOfGas,
     OTHER(i32),
 }
 
@@ -100,7 +100,7 @@ impl ModuleError {
 
         match code {
             -1 => Self::PANIC,
-            -2 => Self::OUT_OF_GAS,
+            -2 => Self::OutOfGas,
             v => Self::OTHER(v),
         }
     }
@@ -110,7 +110,7 @@ impl From<ModuleError> for i32 {
     fn from(err: ModuleError) -> Self {
         match err {
             ModuleError::PANIC => -1,
-            ModuleError::OUT_OF_GAS => -2,
+            ModuleError::OutOfGas => -2,
             ModuleError::OTHER(c) => c,
         }
     }

--- a/piecrust-uplink/src/state.rs
+++ b/piecrust-uplink/src/state.rs
@@ -81,9 +81,9 @@ use core::ops::{Deref, DerefMut};
 #[derive(Debug, Clone, Copy, Archive, Serialize, Deserialize)]
 #[archive_attr(derive(CheckBytes))]
 pub enum ModuleError {
-    Panic,
-    OutOfGas,
-    Other(i32),
+    PANIC,
+    OUT_OF_GAS,
+    OTHER(i32),
 }
 
 impl ModuleError {
@@ -99,9 +99,9 @@ impl ModuleError {
         }
 
         match code {
-            -1 => Self::Panic,
-            -2 => Self::OutOfGas,
-            v => Self::Other(v),
+            -1 => Self::PANIC,
+            -2 => Self::OUT_OF_GAS,
+            v => Self::OTHER(v),
         }
     }
 }
@@ -109,9 +109,9 @@ impl ModuleError {
 impl From<ModuleError> for i32 {
     fn from(err: ModuleError) -> Self {
         match err {
-            ModuleError::Panic => -1,
-            ModuleError::OutOfGas => -2,
-            ModuleError::Other(c) => c,
+            ModuleError::PANIC => -1,
+            ModuleError::OUT_OF_GAS => -2,
+            ModuleError::OTHER(c) => c,
         }
     }
 }

--- a/piecrust-uplink/src/state.rs
+++ b/piecrust-uplink/src/state.rs
@@ -82,7 +82,7 @@ use core::ops::{Deref, DerefMut};
 #[archive_attr(derive(CheckBytes))]
 pub enum ModuleError {
     PANIC,
-    OutOfGas,
+    OUT_OF_GAS,
     OTHER(i32),
 }
 
@@ -100,7 +100,7 @@ impl ModuleError {
 
         match code {
             -1 => Self::PANIC,
-            -2 => Self::OutOfGas,
+            -2 => Self::OUT_OF_GAS,
             v => Self::OTHER(v),
         }
     }
@@ -110,7 +110,7 @@ impl From<ModuleError> for i32 {
     fn from(err: ModuleError) -> Self {
         match err {
             ModuleError::PANIC => -1,
-            ModuleError::OutOfGas => -2,
+            ModuleError::OUT_OF_GAS => -2,
             ModuleError::OTHER(c) => c,
         }
     }

--- a/piecrust-uplink/src/state.rs
+++ b/piecrust-uplink/src/state.rs
@@ -82,7 +82,7 @@ use core::ops::{Deref, DerefMut};
 #[archive_attr(derive(CheckBytes))]
 pub enum ModuleError {
     PANIC,
-    OUT_OF_GAS,
+    OUTOFGAS,
     OTHER(i32),
 }
 
@@ -100,7 +100,7 @@ impl ModuleError {
 
         match code {
             -1 => Self::PANIC,
-            -2 => Self::OUT_OF_GAS,
+            -2 => Self::OUTOFGAS,
             v => Self::OTHER(v),
         }
     }
@@ -110,7 +110,7 @@ impl From<ModuleError> for i32 {
     fn from(err: ModuleError) -> Self {
         match err {
             ModuleError::PANIC => -1,
-            ModuleError::OUT_OF_GAS => -2,
+            ModuleError::OUTOFGAS => -2,
             ModuleError::OTHER(c) => c,
         }
     }

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Made session data settable only at deploy time. [#181]
 - Changed deploy API to accept `Into<DeployData>`. [#158]
 - Made modules compile at deploy time rather than on first query/transaction time. [#162]
 
@@ -34,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - First `piecrust` release
 
 <!-- ISSUES -->
+[#181]: https://github.com/dusk-network/piecrust/issues/181
 [#178]: https://github.com/dusk-network/piecrust/issues/178
 [#167]: https://github.com/dusk-network/piecrust/issues/167
 [#162]: https://github.com/dusk-network/piecrust/issues/162

--- a/piecrust/src/error.rs
+++ b/piecrust/src/error.rs
@@ -120,7 +120,7 @@ impl From<Error> for ModuleError {
     fn from(err: Error) -> Self {
         // TODO implement this fully
         match err {
-            Error::OutOfPoints => Self::OUT_OF_GAS,
+            Error::OutOfPoints => Self::OutOfGas,
             _ => Self::OTHER(OTHER_STATUS_CODE),
         }
     }

--- a/piecrust/src/error.rs
+++ b/piecrust/src/error.rs
@@ -120,8 +120,8 @@ impl From<Error> for ModuleError {
     fn from(err: Error) -> Self {
         // TODO implement this fully
         match err {
-            Error::OutOfPoints => Self::OutOfGas,
-            _ => Self::Other(OTHER_STATUS_CODE),
+            Error::OutOfPoints => Self::OUT_OF_GAS,
+            _ => Self::OTHER(OTHER_STATUS_CODE),
         }
     }
 }

--- a/piecrust/src/error.rs
+++ b/piecrust/src/error.rs
@@ -120,7 +120,7 @@ impl From<Error> for ModuleError {
     fn from(err: Error) -> Self {
         // TODO implement this fully
         match err {
-            Error::OutOfPoints => Self::OUT_OF_GAS,
+            Error::OutOfPoints => Self::OUTOFGAS,
             _ => Self::OTHER(OTHER_STATUS_CODE),
         }
     }

--- a/piecrust/src/error.rs
+++ b/piecrust/src/error.rs
@@ -120,7 +120,7 @@ impl From<Error> for ModuleError {
     fn from(err: Error) -> Self {
         // TODO implement this fully
         match err {
-            Error::OutOfPoints => Self::OutOfGas,
+            Error::OutOfPoints => Self::OUT_OF_GAS,
             _ => Self::OTHER(OTHER_STATUS_CODE),
         }
     }

--- a/piecrust/src/imports.rs
+++ b/piecrust/src/imports.rs
@@ -288,7 +288,9 @@ fn spent(fenv: FunctionEnvMut<Env>) -> u64 {
 fn owner(fenv: FunctionEnvMut<Env>) -> u32 {
     let env = fenv.data();
     let self_id = env.self_module_id();
-    let module_metadata = env.metadata(self_id).expect("metadata should exist");
+    let module_metadata = env
+        .module_metadata(self_id)
+        .expect("module metadata should exist");
     let slice = module_metadata.owner.as_slice();
     let len = slice.len();
     env.self_instance()
@@ -299,7 +301,9 @@ fn owner(fenv: FunctionEnvMut<Env>) -> u32 {
 fn self_id(fenv: FunctionEnvMut<Env>) -> u32 {
     let env = fenv.data();
     let self_id = env.self_module_id();
-    let module_metadata = env.metadata(self_id).expect("metadata should exist");
+    let module_metadata = env
+        .module_metadata(self_id)
+        .expect("module metadata should exist");
     let slice = module_metadata.module_id.as_bytes();
     let len = slice.len();
     env.self_instance()

--- a/piecrust/src/lib.rs
+++ b/piecrust/src/lib.rs
@@ -81,7 +81,7 @@
 //! let mut vm = VM::ephemeral().unwrap();
 //!
 //! const OWNER: [u8; 32] = [0u8; 32];
-//! let mut session = vm.genesis_session(SessionData::new());
+//! let mut session = vm.session(SessionData::builder()).unwrap();
 //! let counter_id = session.deploy(module_bytecode!("counter"), ModuleData::builder(OWNER)).unwrap();
 //!
 //! assert_eq!(session.query::<(), i64>(counter_id, "read_value", &()).unwrap(), 0xfc);
@@ -119,7 +119,7 @@ mod types;
 mod vm;
 
 pub use error::Error;
-pub use module::{DeployDataBuilder, ModuleData};
+pub use module::{ModuleDataBuilder, ModuleData};
 pub use session::{Session, SessionData};
 pub use vm::{HostQuery, VM};
 

--- a/piecrust/src/lib.rs
+++ b/piecrust/src/lib.rs
@@ -119,7 +119,7 @@ mod types;
 mod vm;
 
 pub use error::Error;
-pub use module::{ModuleData, DeployDataBuilder};
+pub use module::{DeployDataBuilder, ModuleData};
 pub use session::Session;
 pub use vm::{HostQuery, VM};
 

--- a/piecrust/src/lib.rs
+++ b/piecrust/src/lib.rs
@@ -119,7 +119,7 @@ mod types;
 mod vm;
 
 pub use error::Error;
-pub use module::{ModuleDataBuilder, ModuleData};
+pub use module::{ModuleData, ModuleDataBuilder};
 pub use session::{Session, SessionData};
 pub use vm::{HostQuery, VM};
 

--- a/piecrust/src/lib.rs
+++ b/piecrust/src/lib.rs
@@ -77,11 +77,11 @@
 //!
 //! # Usage
 //! ```
-//! use piecrust::{module_bytecode, ModuleData, VM};
+//! use piecrust::{module_bytecode, ModuleData, SessionData, VM};
 //! let mut vm = VM::ephemeral().unwrap();
 //!
 //! const OWNER: [u8; 32] = [0u8; 32];
-//! let mut session = vm.genesis_session();
+//! let mut session = vm.genesis_session(SessionData::new());
 //! let counter_id = session.deploy(module_bytecode!("counter"), ModuleData::builder(OWNER)).unwrap();
 //!
 //! assert_eq!(session.query::<(), i64>(counter_id, "read_value", &()).unwrap(), 0xfc);
@@ -120,7 +120,7 @@ mod vm;
 
 pub use error::Error;
 pub use module::{DeployDataBuilder, ModuleData};
-pub use session::Session;
+pub use session::{Session, SessionData};
 pub use vm::{HostQuery, VM};
 
 // re-exports

--- a/piecrust/src/lib.rs
+++ b/piecrust/src/lib.rs
@@ -77,12 +77,12 @@
 //!
 //! # Usage
 //! ```
-//! use piecrust::{module_bytecode, DeployData, VM};
+//! use piecrust::{module_bytecode, ModuleData, VM};
 //! let mut vm = VM::ephemeral().unwrap();
 //!
 //! const OWNER: [u8; 32] = [0u8; 32];
 //! let mut session = vm.genesis_session();
-//! let counter_id = session.deploy(module_bytecode!("counter"), DeployData::builder(OWNER)).unwrap();
+//! let counter_id = session.deploy(module_bytecode!("counter"), ModuleData::builder(OWNER)).unwrap();
 //!
 //! assert_eq!(session.query::<(), i64>(counter_id, "read_value", &()).unwrap(), 0xfc);
 //! session.transact::<(), ()>(counter_id, "increment", &()).unwrap();
@@ -119,7 +119,7 @@ mod types;
 mod vm;
 
 pub use error::Error;
-pub use module::{DeployData, DeployDataBuilder};
+pub use module::{ModuleData, DeployDataBuilder};
 pub use session::Session;
 pub use vm::{HostQuery, VM};
 

--- a/piecrust/src/module.rs
+++ b/piecrust/src/module.rs
@@ -27,8 +27,8 @@ impl<'a> ModuleData<'a, ()> {
     ///
     /// This function returns a builder that can be used to set optional fields
     /// in module deployment.
-    pub fn builder(owner: [u8; 32]) -> DeployDataBuilder<'a, ()> {
-        DeployDataBuilder {
+    pub fn builder(owner: [u8; 32]) -> ModuleDataBuilder<'a, ()> {
+        ModuleDataBuilder {
             module_id: None,
             constructor_arg: None,
             owner,
@@ -36,19 +36,19 @@ impl<'a> ModuleData<'a, ()> {
     }
 }
 
-impl<'a, A> From<DeployDataBuilder<'a, A>> for ModuleData<'a, A> {
-    fn from(builder: DeployDataBuilder<'a, A>) -> Self {
+impl<'a, A> From<ModuleDataBuilder<'a, A>> for ModuleData<'a, A> {
+    fn from(builder: ModuleDataBuilder<'a, A>) -> Self {
         builder.build()
     }
 }
 
-pub struct DeployDataBuilder<'a, A> {
+pub struct ModuleDataBuilder<'a, A> {
     module_id: Option<ModuleId>,
     owner: [u8; 32],
     constructor_arg: Option<&'a A>,
 }
 
-impl<'a, A> DeployDataBuilder<'a, A> {
+impl<'a, A> ModuleDataBuilder<'a, A> {
     /// Set the deployment module ID.
     pub fn module_id(mut self, id: ModuleId) -> Self {
         self.module_id = Some(id);
@@ -56,8 +56,8 @@ impl<'a, A> DeployDataBuilder<'a, A> {
     }
 
     /// Set the constructor argument for deployment.
-    pub fn constructor_arg<B>(self, arg: &B) -> DeployDataBuilder<B> {
-        DeployDataBuilder {
+    pub fn constructor_arg<B>(self, arg: &B) -> ModuleDataBuilder<B> {
+        ModuleDataBuilder {
             module_id: self.module_id,
             owner: self.owner,
             constructor_arg: Some(arg),

--- a/piecrust/src/module.rs
+++ b/piecrust/src/module.rs
@@ -14,7 +14,7 @@ use crate::error::Error;
 use crate::instance::Store;
 use piecrust_uplink::ModuleId;
 
-pub struct DeployData<'a, A> {
+pub struct ModuleData<'a, A> {
     pub(crate) module_id: Option<ModuleId>,
     pub(crate) constructor_arg: Option<&'a A>,
     pub(crate) owner: [u8; 32],
@@ -22,7 +22,7 @@ pub struct DeployData<'a, A> {
 
 // `()` is done on purpose, since by default it should be that the constructor
 // takes no argument.
-impl<'a> DeployData<'a, ()> {
+impl<'a> ModuleData<'a, ()> {
     /// Build a deploy data structure.
     ///
     /// This function returns a builder that can be used to set optional fields
@@ -36,7 +36,7 @@ impl<'a> DeployData<'a, ()> {
     }
 }
 
-impl<'a, A> From<DeployDataBuilder<'a, A>> for DeployData<'a, A> {
+impl<'a, A> From<DeployDataBuilder<'a, A>> for ModuleData<'a, A> {
     fn from(builder: DeployDataBuilder<'a, A>) -> Self {
         builder.build()
     }
@@ -64,8 +64,8 @@ impl<'a, A> DeployDataBuilder<'a, A> {
         }
     }
 
-    pub fn build(self) -> DeployData<'a, A> {
-        DeployData {
+    pub fn build(self) -> ModuleData<'a, A> {
+        ModuleData {
             module_id: self.module_id,
             constructor_arg: self.constructor_arg,
             owner: self.owner,

--- a/piecrust/src/session.rs
+++ b/piecrust/src/session.rs
@@ -757,8 +757,11 @@ impl Session {
         Ok(ret)
     }
 
-    pub fn metadata(&self, module_id: &ModuleId) -> Option<&ModuleMetadata> {
-        self.module_session.metadata(module_id)
+    pub fn module_metadata(
+        &self,
+        module_id: &ModuleId,
+    ) -> Option<&ModuleMetadata> {
+        self.module_session.module_metadata(module_id)
     }
 }
 

--- a/piecrust/src/session.rs
+++ b/piecrust/src/session.rs
@@ -796,18 +796,37 @@ struct Call {
     limit: u64,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct SessionData {
     data: BTreeMap<Cow<'static, str>, Vec<u8>>,
+    pub base: Option<[u8; 32]>,
 }
 
 impl SessionData {
-    pub fn new() -> Self {
-        Self {
+    pub fn builder() -> SessionDataBuilder {
+        SessionDataBuilder {
             data: BTreeMap::new(),
+            base: None,
         }
     }
 
+    fn get(&self, name: &str) -> Option<Vec<u8>> {
+        self.data.get(name).cloned()
+    }
+}
+
+impl From<SessionDataBuilder> for SessionData {
+    fn from(builder: SessionDataBuilder) -> Self {
+        builder.build()
+    }
+}
+
+pub struct SessionDataBuilder {
+    data: BTreeMap<Cow<'static, str>, Vec<u8>>,
+    base: Option<[u8; 32]>,
+}
+
+impl SessionDataBuilder {
     pub fn insert<S, V>(mut self, name: S, value: V) -> Self
     where
         S: Into<Cow<'static, str>>,
@@ -818,13 +837,15 @@ impl SessionData {
         self
     }
 
-    fn get(&self, name: &str) -> Option<Vec<u8>> {
-        self.data.get(name).cloned()
+    pub fn base(mut self, base: [u8; 32]) -> Self {
+        self.base = Some(base);
+        self
     }
-}
 
-impl Default for SessionData {
-    fn default() -> Self {
-        Self::new()
+    fn build(&self) -> SessionData {
+        SessionData {
+            data: self.data.clone(),
+            base: self.base
+        }
     }
 }

--- a/piecrust/src/session.rs
+++ b/piecrust/src/session.rs
@@ -26,7 +26,7 @@ use wasmer_types::WASM_PAGE_SIZE;
 
 use crate::event::Event;
 use crate::instance::WrappedInstance;
-use crate::module::{DeployData, ModuleMetadata, WrappedModule};
+use crate::module::{ModuleData, ModuleMetadata, WrappedModule};
 use crate::store::{ModuleSession, Objectcode};
 use crate::types::StandardBufSerializer;
 use crate::vm::HostQueries;
@@ -120,7 +120,7 @@ impl Session {
     ) -> Result<ModuleId, Error>
     where
         A: 'a + for<'b> Serialize<StandardBufSerializer<'b>>,
-        D: Into<DeployData<'a, A>>,
+        D: Into<ModuleData<'a, A>>,
     {
         let mut deploy_data = deploy_data.into();
 

--- a/piecrust/src/session.rs
+++ b/piecrust/src/session.rs
@@ -63,7 +63,7 @@ pub struct Session {
     instance_map: BTreeMap<ModuleId, (*mut WrappedInstance, u64)>,
     debug: Vec<String>,
     events: Vec<Event>,
-    data: SessionMetadata,
+    data: SessionData,
 
     module_session: ModuleSession,
     host_queries: HostQueries,
@@ -86,13 +86,14 @@ impl Session {
     pub(crate) fn new(
         module_session: ModuleSession,
         host_queries: HostQueries,
+        data: SessionData,
     ) -> Self {
         Session {
             call_stack: CallStack::new(),
             instance_map: BTreeMap::new(),
             debug: vec![],
             events: vec![],
-            data: SessionMetadata::new(),
+            data,
             module_session,
             host_queries,
             limit: DEFAULT_LIMIT,
@@ -807,12 +808,12 @@ struct Call {
 }
 
 #[derive(Debug)]
-pub struct SessionMetadata {
+pub struct SessionData {
     data: BTreeMap<Cow<'static, str>, Vec<u8>>,
 }
 
-impl SessionMetadata {
-    fn new() -> Self {
+impl SessionData {
+    pub fn new() -> Self {
         Self {
             data: BTreeMap::new(),
         }

--- a/piecrust/src/session.rs
+++ b/piecrust/src/session.rs
@@ -822,3 +822,9 @@ impl SessionData {
         self.data.get(name).cloned()
     }
 }
+
+impl Default for SessionData {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/piecrust/src/session.rs
+++ b/piecrust/src/session.rs
@@ -845,7 +845,7 @@ impl SessionDataBuilder {
     fn build(&self) -> SessionData {
         SessionData {
             data: self.data.clone(),
-            base: self.base
+            base: self.base,
         }
     }
 }

--- a/piecrust/src/session.rs
+++ b/piecrust/src/session.rs
@@ -530,9 +530,7 @@ impl Session {
         c(&self.debug)
     }
 
-    /// Returns the value of a metadata item previously set using [`set_meta`].
-    ///
-    /// [`set_meta`]: Session::set_meta
+    /// Returns the value of a metadata item.
     pub fn meta(&self, name: &str) -> Option<Vec<u8>> {
         self.data.get(name)
     }

--- a/piecrust/src/store.rs
+++ b/piecrust/src/store.rs
@@ -28,7 +28,7 @@ pub use bytecode::Bytecode;
 use diff::diff;
 pub use memory::Memory;
 pub use metadata::Metadata;
-use module_session::ModuleData;
+use module_session::ModuleDataEntry;
 pub use module_session::ModuleSession;
 pub use objectcode::Objectcode;
 use piecrust_uplink::ModuleId;
@@ -290,7 +290,7 @@ pub(crate) struct Commit {
 
 pub(crate) enum Call {
     Commit {
-        modules: BTreeMap<ModuleId, ModuleData>,
+        modules: BTreeMap<ModuleId, ModuleDataEntry>,
         base: Option<(Root, Commit)>,
         replier: mpsc::SyncSender<io::Result<(Root, Commit)>>,
     },
@@ -471,7 +471,7 @@ fn write_commit<P: AsRef<Path>>(
     root_dir: P,
     commits: &mut BTreeMap<Root, Commit>,
     base: Option<(Root, Commit)>,
-    commit_modules: BTreeMap<ModuleId, ModuleData>,
+    commit_modules: BTreeMap<ModuleId, ModuleDataEntry>,
 ) -> io::Result<(Root, Commit)> {
     let root_dir = root_dir.as_ref();
 
@@ -510,7 +510,7 @@ fn write_commit_inner<P: AsRef<Path>>(
     commit_dir: P,
     base: Option<(Root, Commit)>,
     modules: BTreeMap<ModuleId, Root>,
-    commit_modules: BTreeMap<ModuleId, ModuleData>,
+    commit_modules: BTreeMap<ModuleId, ModuleDataEntry>,
 ) -> io::Result<Commit> {
     let root_dir = root_dir.as_ref();
     let commit_dir = commit_dir.as_ref();
@@ -695,7 +695,7 @@ fn compute_root<'a, I>(
     modules: I,
 ) -> (Root, BTreeMap<ModuleId, Root>)
 where
-    I: IntoIterator<Item = (&'a ModuleId, &'a ModuleData)>,
+    I: IntoIterator<Item = (&'a ModuleId, &'a ModuleDataEntry)>,
 {
     let iter = modules.into_iter();
 

--- a/piecrust/src/store/module_session.rs
+++ b/piecrust/src/store/module_session.rs
@@ -232,7 +232,10 @@ impl ModuleSession {
     }
 
     /// Provides metadata of the module with a given `module_id`.
-    pub fn metadata(&self, module_id: &ModuleId) -> Option<&ModuleMetadata> {
+    pub fn module_metadata(
+        &self,
+        module_id: &ModuleId,
+    ) -> Option<&ModuleMetadata> {
         self.modules
             .get(module_id)
             .map(|store_data| store_data.metadata.data())

--- a/piecrust/src/store/module_session.rs
+++ b/piecrust/src/store/module_session.rs
@@ -20,7 +20,7 @@ use crate::store::{
 };
 
 #[derive(Debug, Clone)]
-pub struct ModuleData {
+pub struct ModuleDataEntry {
     pub bytecode: Bytecode,
     pub objectcode: Objectcode,
     pub metadata: Metadata,
@@ -38,7 +38,7 @@ pub struct ModuleData {
 /// [`commit`]: ModuleSession::commit
 #[derive(Debug)]
 pub struct ModuleSession {
-    modules: BTreeMap<ModuleId, ModuleData>,
+    modules: BTreeMap<ModuleId, ModuleDataEntry>,
 
     base: Option<(Root, Commit)>,
     root_dir: PathBuf,
@@ -129,7 +129,7 @@ impl ModuleSession {
     pub fn module(
         &mut self,
         module: ModuleId,
-    ) -> io::Result<Option<ModuleData>> {
+    ) -> io::Result<Option<ModuleDataEntry>> {
         match self.modules.entry(module) {
             Vacant(entry) => match &self.base {
                 None => Ok(None),
@@ -166,7 +166,7 @@ impl ModuleSession {
                                 };
 
                             let module = entry
-                                .insert(ModuleData {
+                                .insert(ModuleDataEntry {
                                     bytecode,
                                     objectcode,
                                     metadata,
@@ -220,7 +220,7 @@ impl ModuleSession {
 
         self.modules.insert(
             module_id,
-            ModuleData {
+            ModuleDataEntry {
                 bytecode,
                 objectcode,
                 metadata,

--- a/piecrust/src/vm.rs
+++ b/piecrust/src/vm.rs
@@ -106,10 +106,10 @@ impl VM {
     ///
     /// [`Session`]: Session
     /// [`genesis_session`]: VM::genesis_session
-    pub fn session<D>(&self, data: D) -> Result<Session, Error>
-    where
-        D: Into<SessionData>,
-    {
+    pub fn session(
+        &self,
+        data: impl Into<SessionData>,
+    ) -> Result<Session, Error> {
         let data = data.into();
         let module_session = match data.base {
             Some(base) => self

--- a/piecrust/src/vm.rs
+++ b/piecrust/src/vm.rs
@@ -106,24 +106,17 @@ impl VM {
     ///
     /// [`Session`]: Session
     /// [`genesis_session`]: VM::genesis_session
-    pub fn session<D>(
-        &self,
-        data: D,
-    ) -> Result<Session, Error>
+    pub fn session<D>(&self, data: D) -> Result<Session, Error>
     where
-        D: Into<SessionData>
+        D: Into<SessionData>,
     {
         let data = data.into();
         let module_session = match data.base {
-            Some(base) => {
-                self
-                    .store
-                    .session(base)
-                    .map_err(|err| PersistenceError(Arc::new(err)))?
-            },
-            _ => {
-                self.store.genesis_session()
-            }
+            Some(base) => self
+                .store
+                .session(base)
+                .map_err(|err| PersistenceError(Arc::new(err)))?,
+            _ => self.store.genesis_session(),
         };
         Ok(Session::new(
             module_session,

--- a/piecrust/src/vm.rs
+++ b/piecrust/src/vm.rs
@@ -13,7 +13,7 @@ use std::thread;
 
 use tempfile::tempdir;
 
-use crate::session::Session;
+use crate::session::{Session, SessionData};
 use crate::store::ModuleStore;
 use crate::Error::{self, PersistenceError};
 
@@ -110,12 +110,12 @@ impl VM {
     ///
     /// [`Session`]: Session
     /// [`genesis_session`]: VM::genesis_session
-    pub fn session(&self, base: [u8; 32]) -> Result<Session, Error> {
+    pub fn session(&self, base: [u8; 32], data: SessionData) -> Result<Session, Error> {
         let module_session = self
             .store
             .session(base)
             .map_err(|err| PersistenceError(Arc::new(err)))?;
-        Ok(Session::new(module_session, self.host_queries.clone()))
+        Ok(Session::new(module_session, self.host_queries.clone(), data))
     }
 
     /// Spawn a [`Session`] with no commit as a base.
@@ -125,9 +125,9 @@ impl VM {
     ///
     /// [`Session`]: Session
     /// [`session`]: VM::session
-    pub fn genesis_session(&self) -> Session {
+    pub fn genesis_session(&self, data: SessionData) -> Session {
         let module_session = self.store.genesis_session();
-        Session::new(module_session, self.host_queries.clone())
+        Session::new(module_session, self.host_queries.clone(), data)
     }
 
     /// Return all existing commits.

--- a/piecrust/src/vm.rs
+++ b/piecrust/src/vm.rs
@@ -110,12 +110,20 @@ impl VM {
     ///
     /// [`Session`]: Session
     /// [`genesis_session`]: VM::genesis_session
-    pub fn session(&self, base: [u8; 32], data: SessionData) -> Result<Session, Error> {
+    pub fn session(
+        &self,
+        base: [u8; 32],
+        data: SessionData,
+    ) -> Result<Session, Error> {
         let module_session = self
             .store
             .session(base)
             .map_err(|err| PersistenceError(Arc::new(err)))?;
-        Ok(Session::new(module_session, self.host_queries.clone(), data))
+        Ok(Session::new(
+            module_session,
+            self.host_queries.clone(),
+            data,
+        ))
     }
 
     /// Spawn a [`Session`] with no commit as a base.

--- a/piecrust/tests/box.rs
+++ b/piecrust/tests/box.rs
@@ -12,7 +12,7 @@ const OWNER: [u8; 32] = [0u8; 32];
 pub fn box_set_get() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session(SessionData::new());
+    let mut session = vm.session(SessionData::builder())?;
 
     let id =
         session.deploy(module_bytecode!("box"), ModuleData::builder(OWNER))?;

--- a/piecrust/tests/box.rs
+++ b/piecrust/tests/box.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, DeployData, Error, VM};
+use piecrust::{module_bytecode, ModuleData, Error, VM};
 
 const OWNER: [u8; 32] = [0u8; 32];
 
@@ -15,7 +15,7 @@ pub fn box_set_get() -> Result<(), Error> {
     let mut session = vm.genesis_session();
 
     let id =
-        session.deploy(module_bytecode!("box"), DeployData::builder(OWNER))?;
+        session.deploy(module_bytecode!("box"), ModuleData::builder(OWNER))?;
 
     let value: Option<i16> = session.query(id, "get", &())?;
 

--- a/piecrust/tests/box.rs
+++ b/piecrust/tests/box.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, Error, ModuleData, VM};
+use piecrust::{module_bytecode, Error, ModuleData, SessionData, VM};
 
 const OWNER: [u8; 32] = [0u8; 32];
 
@@ -12,7 +12,7 @@ const OWNER: [u8; 32] = [0u8; 32];
 pub fn box_set_get() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session();
+    let mut session = vm.genesis_session(SessionData::new());
 
     let id =
         session.deploy(module_bytecode!("box"), ModuleData::builder(OWNER))?;

--- a/piecrust/tests/box.rs
+++ b/piecrust/tests/box.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, ModuleData, Error, VM};
+use piecrust::{module_bytecode, Error, ModuleData, VM};
 
 const OWNER: [u8; 32] = [0u8; 32];
 

--- a/piecrust/tests/callcenter.rs
+++ b/piecrust/tests/callcenter.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, ModuleData, Error, VM};
+use piecrust::{module_bytecode, Error, ModuleData, VM};
 use piecrust_uplink::{
     ModuleError, ModuleId, RawQuery, RawResult, RawTransaction,
 };

--- a/piecrust/tests/callcenter.rs
+++ b/piecrust/tests/callcenter.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, Error, ModuleData, VM};
+use piecrust::{module_bytecode, Error, ModuleData, SessionData, VM};
 use piecrust_uplink::{
     ModuleError, ModuleId, RawQuery, RawResult, RawTransaction,
 };
@@ -15,7 +15,7 @@ const OWNER: [u8; 32] = [0u8; 32];
 pub fn cc_read_counter() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session();
+    let mut session = vm.genesis_session(SessionData::new());
 
     let counter_id = session
         .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;
@@ -39,7 +39,7 @@ pub fn cc_read_counter() -> Result<(), Error> {
 pub fn cc_direct() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session();
+    let mut session = vm.genesis_session(SessionData::new());
 
     let counter_id = session
         .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;
@@ -73,7 +73,7 @@ pub fn cc_direct() -> Result<(), Error> {
 pub fn cc_passthrough() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session();
+    let mut session = vm.genesis_session(SessionData::new());
 
     let center_id = session
         .deploy(module_bytecode!("callcenter"), ModuleData::builder(OWNER))?;
@@ -91,7 +91,7 @@ pub fn cc_passthrough() -> Result<(), Error> {
 pub fn cc_delegated_read() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session();
+    let mut session = vm.genesis_session(SessionData::new());
 
     let counter_id = session
         .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;
@@ -122,7 +122,7 @@ pub fn cc_delegated_write() -> Result<(), Error> {
 
     let rt = RawTransaction::new("increment", ());
 
-    let mut session = vm.genesis_session();
+    let mut session = vm.genesis_session(SessionData::new());
     let counter_id = session
         .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;
     let center_id = session
@@ -141,7 +141,7 @@ pub fn cc_delegated_write() -> Result<(), Error> {
 pub fn cc_self() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session();
+    let mut session = vm.genesis_session(SessionData::new());
 
     let center_id = session
         .deploy(module_bytecode!("callcenter"), ModuleData::builder(OWNER))?;
@@ -158,7 +158,7 @@ pub fn cc_self() -> Result<(), Error> {
 pub fn cc_caller() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session();
+    let mut session = vm.genesis_session(SessionData::new());
 
     let center_id = session
         .deploy(module_bytecode!("callcenter"), ModuleData::builder(OWNER))?;
@@ -175,7 +175,7 @@ pub fn cc_caller() -> Result<(), Error> {
 pub fn cc_caller_uninit() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session();
+    let mut session = vm.genesis_session(SessionData::new());
 
     let center_id = session
         .deploy(module_bytecode!("callcenter"), ModuleData::builder(OWNER))?;
@@ -190,7 +190,7 @@ pub fn cc_caller_uninit() -> Result<(), Error> {
 pub fn cc_self_id() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session();
+    let mut session = vm.genesis_session(SessionData::new());
 
     let center_id = session
         .deploy(module_bytecode!("callcenter"), ModuleData::builder(OWNER))?;

--- a/piecrust/tests/callcenter.rs
+++ b/piecrust/tests/callcenter.rs
@@ -15,7 +15,7 @@ const OWNER: [u8; 32] = [0u8; 32];
 pub fn cc_read_counter() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session(SessionData::new());
+    let mut session = vm.session(SessionData::builder())?;
 
     let counter_id = session
         .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;
@@ -39,7 +39,7 @@ pub fn cc_read_counter() -> Result<(), Error> {
 pub fn cc_direct() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session(SessionData::new());
+    let mut session = vm.session(SessionData::builder())?;
 
     let counter_id = session
         .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;
@@ -73,7 +73,7 @@ pub fn cc_direct() -> Result<(), Error> {
 pub fn cc_passthrough() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session(SessionData::new());
+    let mut session = vm.session(SessionData::builder())?;
 
     let center_id = session
         .deploy(module_bytecode!("callcenter"), ModuleData::builder(OWNER))?;
@@ -91,7 +91,7 @@ pub fn cc_passthrough() -> Result<(), Error> {
 pub fn cc_delegated_read() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session(SessionData::new());
+    let mut session = vm.session(SessionData::builder())?;
 
     let counter_id = session
         .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;
@@ -122,7 +122,7 @@ pub fn cc_delegated_write() -> Result<(), Error> {
 
     let rt = RawTransaction::new("increment", ());
 
-    let mut session = vm.genesis_session(SessionData::new());
+    let mut session = vm.session(SessionData::builder())?;
     let counter_id = session
         .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;
     let center_id = session
@@ -141,7 +141,7 @@ pub fn cc_delegated_write() -> Result<(), Error> {
 pub fn cc_self() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session(SessionData::new());
+    let mut session = vm.session(SessionData::builder())?;
 
     let center_id = session
         .deploy(module_bytecode!("callcenter"), ModuleData::builder(OWNER))?;
@@ -158,7 +158,7 @@ pub fn cc_self() -> Result<(), Error> {
 pub fn cc_caller() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session(SessionData::new());
+    let mut session = vm.session(SessionData::builder())?;
 
     let center_id = session
         .deploy(module_bytecode!("callcenter"), ModuleData::builder(OWNER))?;
@@ -175,7 +175,7 @@ pub fn cc_caller() -> Result<(), Error> {
 pub fn cc_caller_uninit() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session(SessionData::new());
+    let mut session = vm.session(SessionData::builder())?;
 
     let center_id = session
         .deploy(module_bytecode!("callcenter"), ModuleData::builder(OWNER))?;
@@ -190,7 +190,7 @@ pub fn cc_caller_uninit() -> Result<(), Error> {
 pub fn cc_self_id() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session(SessionData::new());
+    let mut session = vm.session(SessionData::builder())?;
 
     let center_id = session
         .deploy(module_bytecode!("callcenter"), ModuleData::builder(OWNER))?;

--- a/piecrust/tests/callcenter.rs
+++ b/piecrust/tests/callcenter.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, DeployData, Error, VM};
+use piecrust::{module_bytecode, ModuleData, Error, VM};
 use piecrust_uplink::{
     ModuleError, ModuleId, RawQuery, RawResult, RawTransaction,
 };
@@ -18,7 +18,7 @@ pub fn cc_read_counter() -> Result<(), Error> {
     let mut session = vm.genesis_session();
 
     let counter_id = session
-        .deploy(module_bytecode!("counter"), DeployData::builder(OWNER))?;
+        .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;
 
     // read direct
 
@@ -26,7 +26,7 @@ pub fn cc_read_counter() -> Result<(), Error> {
     assert_eq!(value, 0xfc);
 
     let center_id = session
-        .deploy(module_bytecode!("callcenter"), DeployData::builder(OWNER))?;
+        .deploy(module_bytecode!("callcenter"), ModuleData::builder(OWNER))?;
 
     // read value through callcenter
     let value: i64 = session.query(center_id, "query_counter", &counter_id)?;
@@ -42,14 +42,14 @@ pub fn cc_direct() -> Result<(), Error> {
     let mut session = vm.genesis_session();
 
     let counter_id = session
-        .deploy(module_bytecode!("counter"), DeployData::builder(OWNER))?;
+        .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;
 
     // read value directly
     let value: i64 = session.query(counter_id, "read_value", &())?;
     assert_eq!(value, 0xfc);
 
     let center_id = session
-        .deploy(module_bytecode!("callcenter"), DeployData::builder(OWNER))?;
+        .deploy(module_bytecode!("callcenter"), ModuleData::builder(OWNER))?;
 
     // read value through callcenter
     let value: i64 = session.query(center_id, "query_counter", &counter_id)?;
@@ -76,7 +76,7 @@ pub fn cc_passthrough() -> Result<(), Error> {
     let mut session = vm.genesis_session();
 
     let center_id = session
-        .deploy(module_bytecode!("callcenter"), DeployData::builder(OWNER))?;
+        .deploy(module_bytecode!("callcenter"), ModuleData::builder(OWNER))?;
 
     let rq = RawQuery::new("read_value", ());
 
@@ -94,9 +94,9 @@ pub fn cc_delegated_read() -> Result<(), Error> {
     let mut session = vm.genesis_session();
 
     let counter_id = session
-        .deploy(module_bytecode!("counter"), DeployData::builder(OWNER))?;
+        .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;
     let center_id = session
-        .deploy(module_bytecode!("callcenter"), DeployData::builder(OWNER))?;
+        .deploy(module_bytecode!("callcenter"), ModuleData::builder(OWNER))?;
 
     let rq = RawQuery::new("read_value", ());
 
@@ -124,9 +124,9 @@ pub fn cc_delegated_write() -> Result<(), Error> {
 
     let mut session = vm.genesis_session();
     let counter_id = session
-        .deploy(module_bytecode!("counter"), DeployData::builder(OWNER))?;
+        .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;
     let center_id = session
-        .deploy(module_bytecode!("callcenter"), DeployData::builder(OWNER))?;
+        .deploy(module_bytecode!("callcenter"), ModuleData::builder(OWNER))?;
 
     session.transact(center_id, "delegate_transaction", &(counter_id, rt))?;
 
@@ -144,7 +144,7 @@ pub fn cc_self() -> Result<(), Error> {
     let mut session = vm.genesis_session();
 
     let center_id = session
-        .deploy(module_bytecode!("callcenter"), DeployData::builder(OWNER))?;
+        .deploy(module_bytecode!("callcenter"), ModuleData::builder(OWNER))?;
 
     // am i calling myself
     let calling_self: bool =
@@ -161,7 +161,7 @@ pub fn cc_caller() -> Result<(), Error> {
     let mut session = vm.genesis_session();
 
     let center_id = session
-        .deploy(module_bytecode!("callcenter"), DeployData::builder(OWNER))?;
+        .deploy(module_bytecode!("callcenter"), ModuleData::builder(OWNER))?;
 
     let value: Result<bool, ModuleError> =
         session.query(center_id, "call_self", &())?;
@@ -178,7 +178,7 @@ pub fn cc_caller_uninit() -> Result<(), Error> {
     let mut session = vm.genesis_session();
 
     let center_id = session
-        .deploy(module_bytecode!("callcenter"), DeployData::builder(OWNER))?;
+        .deploy(module_bytecode!("callcenter"), ModuleData::builder(OWNER))?;
 
     let caller: ModuleId = session.query(center_id, "return_caller", &())?;
     assert_eq!(caller, ModuleId::uninitialized());
@@ -193,7 +193,7 @@ pub fn cc_self_id() -> Result<(), Error> {
     let mut session = vm.genesis_session();
 
     let center_id = session
-        .deploy(module_bytecode!("callcenter"), DeployData::builder(OWNER))?;
+        .deploy(module_bytecode!("callcenter"), ModuleData::builder(OWNER))?;
 
     let value: ModuleId = session.query(center_id, "return_self_id", &())?;
     assert_eq!(value, center_id);

--- a/piecrust/tests/cold-reboot/src/main.rs
+++ b/piecrust/tests/cold-reboot/src/main.rs
@@ -9,7 +9,7 @@ extern crate core;
 use std::path::{Path, PathBuf};
 use std::{env, fs};
 
-use piecrust::{DeployData, ModuleId, VM};
+use piecrust::{ModuleData, ModuleId, VM};
 const COUNTER_ID: ModuleId = {
     let mut bytes = [0u8; 32];
     bytes[0] = 99;
@@ -29,7 +29,7 @@ fn initialize_counter<P: AsRef<Path>>(
 
     session.deploy(
         counter_bytecode,
-        DeployData::builder(OWNER).module_id(COUNTER_ID),
+        ModuleData::builder(OWNER).module_id(COUNTER_ID),
     )?;
     session.transact::<(), ()>(COUNTER_ID, "increment", &())?;
 

--- a/piecrust/tests/cold-reboot/src/main.rs
+++ b/piecrust/tests/cold-reboot/src/main.rs
@@ -9,7 +9,7 @@ extern crate core;
 use std::path::{Path, PathBuf};
 use std::{env, fs};
 
-use piecrust::{ModuleData, ModuleId, VM};
+use piecrust::{ModuleData, ModuleId, SessionData, VM};
 const COUNTER_ID: ModuleId = {
     let mut bytes = [0u8; 32];
     bytes[0] = 99;
@@ -21,7 +21,7 @@ fn initialize_counter<P: AsRef<Path>>(
     vm: &VM,
     commit_id_file_path: P,
 ) -> Result<(), piecrust::Error> {
-    let mut session = vm.genesis_session();
+    let mut session = vm.genesis_session(SessionData::new());
 
     let counter_bytecode = include_bytes!(
         "../../../../target/wasm32-unknown-unknown/release/counter.wasm"
@@ -51,7 +51,7 @@ fn confirm_counter<P: AsRef<Path>>(
     commit_root.copy_from_slice(&commit_root_bytes);
 
     let mut session = vm
-        .session(commit_root)
+        .session(commit_root, SessionData::new())
         .expect("Instantiating session from given root should succeed");
 
     assert_eq!(

--- a/piecrust/tests/cold-reboot/src/main.rs
+++ b/piecrust/tests/cold-reboot/src/main.rs
@@ -21,7 +21,7 @@ fn initialize_counter<P: AsRef<Path>>(
     vm: &VM,
     commit_id_file_path: P,
 ) -> Result<(), piecrust::Error> {
-    let mut session = vm.genesis_session(SessionData::new());
+    let mut session = vm.session(SessionData::builder())?;
 
     let counter_bytecode = include_bytes!(
         "../../../../target/wasm32-unknown-unknown/release/counter.wasm"
@@ -51,7 +51,7 @@ fn confirm_counter<P: AsRef<Path>>(
     commit_root.copy_from_slice(&commit_root_bytes);
 
     let mut session = vm
-        .session(commit_root, SessionData::new())
+        .session(SessionData::builder().base(commit_root))
         .expect("Instantiating session from given root should succeed");
 
     assert_eq!(

--- a/piecrust/tests/commit.rs
+++ b/piecrust/tests/commit.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, ModuleData, Error, Session, VM};
+use piecrust::{module_bytecode, Error, ModuleData, Session, VM};
 use piecrust_uplink::ModuleId;
 use std::thread;
 

--- a/piecrust/tests/commit.rs
+++ b/piecrust/tests/commit.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, DeployData, Error, Session, VM};
+use piecrust::{module_bytecode, ModuleData, Error, Session, VM};
 use piecrust_uplink::ModuleId;
 use std::thread;
 
@@ -17,7 +17,7 @@ fn read_write_session() -> Result<(), Error> {
     {
         let mut session = vm.genesis_session();
         let id = session
-            .deploy(module_bytecode!("counter"), DeployData::builder(OWNER))?;
+            .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;
 
         assert_eq!(session.query::<(), i64>(id, "read_value", &())?, 0xfc);
 
@@ -31,7 +31,7 @@ fn read_write_session() -> Result<(), Error> {
 
     let mut other_session = vm.genesis_session();
     let id = other_session
-        .deploy(module_bytecode!("counter"), DeployData::builder(OWNER))?;
+        .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;
 
     assert_eq!(other_session.query::<(), i64>(id, "read_value", &())?, 0xfc);
 
@@ -52,7 +52,7 @@ fn commit_restore() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
     let mut session_1 = vm.genesis_session();
     let id = session_1
-        .deploy(module_bytecode!("counter"), DeployData::builder(OWNER))?;
+        .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;
     // commit 1
     assert_eq!(session_1.query::<(), i64>(id, "read_value", &())?, 0xfc);
     session_1.transact::<(), ()>(id, "increment", &())?;
@@ -83,9 +83,9 @@ fn commit_restore_two_modules_session() -> Result<(), Error> {
 
     let mut session = vm.genesis_session();
     let id_1 = session
-        .deploy(module_bytecode!("counter"), DeployData::builder(OWNER))?;
+        .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;
     let id_2 =
-        session.deploy(module_bytecode!("box"), DeployData::builder(OWNER))?;
+        session.deploy(module_bytecode!("box"), ModuleData::builder(OWNER))?;
 
     session.transact::<(), ()>(id_1, "increment", &())?;
     session.transact::<i16, ()>(id_2, "set", &0x11)?;
@@ -125,7 +125,7 @@ fn multiple_commits() -> Result<(), Error> {
 
     let mut session = vm.genesis_session();
     let id = session
-        .deploy(module_bytecode!("counter"), DeployData::builder(OWNER))?;
+        .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;
     // commit 1
     assert_eq!(session.query::<(), i64>(id, "read_value", &())?, 0xfc);
     session.transact::<(), ()>(id, "increment", &())?;
@@ -167,7 +167,7 @@ fn concurrent_sessions() -> Result<(), Error> {
 
     let mut session = vm.genesis_session();
     let counter = session
-        .deploy(module_bytecode!("counter"), DeployData::builder(OWNER))?;
+        .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;
 
     assert_eq!(session.query::<(), i64>(counter, "read_value", &())?, 0xfc);
 
@@ -254,7 +254,7 @@ fn squashing() -> Result<(), Error> {
 
     let mut session = vm.genesis_session();
     let counter = session
-        .deploy(module_bytecode!("counter"), DeployData::builder(OWNER))?;
+        .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;
 
     assert_eq!(session.query::<(), i64>(counter, "read_value", &())?, 0xfc);
 

--- a/piecrust/tests/commit.rs
+++ b/piecrust/tests/commit.rs
@@ -15,7 +15,7 @@ fn read_write_session() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
     {
-        let mut session = vm.genesis_session(SessionData::new());
+        let mut session = vm.session(SessionData::builder())?;
         let id = session
             .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;
 
@@ -29,7 +29,7 @@ fn read_write_session() -> Result<(), Error> {
     // mutable session dropped without committing.
     // old counter value still accessible.
 
-    let mut other_session = vm.genesis_session(SessionData::new());
+    let mut other_session = vm.session(SessionData::builder())?;
     let id = other_session
         .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;
 
@@ -41,7 +41,7 @@ fn read_write_session() -> Result<(), Error> {
 
     // session committed, new value accessible
 
-    let mut session = vm.session(_commit_id, SessionData::new())?;
+    let mut session = vm.session(SessionData::builder().base(_commit_id))?;
 
     assert_eq!(session.query::<(), i64>(id, "read_value", &())?, 0xfd);
     Ok(())
@@ -50,7 +50,7 @@ fn read_write_session() -> Result<(), Error> {
 #[test]
 fn commit_restore() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
-    let mut session_1 = vm.genesis_session(SessionData::new());
+    let mut session_1 = vm.session(SessionData::builder())?;
     let id = session_1
         .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;
     // commit 1
@@ -59,20 +59,20 @@ fn commit_restore() -> Result<(), Error> {
     let commit_1 = session_1.commit()?;
 
     // commit 2
-    let mut session_2 = vm.session(commit_1, SessionData::new())?;
+    let mut session_2 = vm.session(SessionData::builder().base(commit_1))?;
     assert_eq!(session_2.query::<(), i64>(id, "read_value", &())?, 0xfd);
     session_2.transact::<(), ()>(id, "increment", &())?;
     session_2.transact::<(), ()>(id, "increment", &())?;
     let commit_2 = session_2.commit()?;
-    let mut session_2 = vm.session(commit_2, SessionData::new())?;
+    let mut session_2 = vm.session(SessionData::builder().base(commit_2))?;
     assert_eq!(session_2.query::<(), i64>(id, "read_value", &())?, 0xff);
 
     // restore commit 1
-    let mut session_3 = vm.session(commit_1, SessionData::new())?;
+    let mut session_3 = vm.session(SessionData::builder().base(commit_1))?;
     assert_eq!(session_3.query::<(), i64>(id, "read_value", &())?, 0xfd);
 
     // restore commit 2
-    let mut session_4 = vm.session(commit_2, SessionData::new())?;
+    let mut session_4 = vm.session(SessionData::builder().base(commit_2))?;
     assert_eq!(session_4.query::<(), i64>(id, "read_value", &())?, 0xff);
     Ok(())
 }
@@ -81,7 +81,7 @@ fn commit_restore() -> Result<(), Error> {
 fn commit_restore_two_modules_session() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session(SessionData::new());
+    let mut session = vm.session(SessionData::builder())?;
     let id_1 = session
         .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;
     let id_2 =
@@ -97,18 +97,18 @@ fn commit_restore_two_modules_session() -> Result<(), Error> {
 
     let commit_1 = session.commit()?;
 
-    let mut session = vm.session(commit_1, SessionData::new())?;
+    let mut session = vm.session(SessionData::builder().base(commit_1))?;
     session.transact::<(), ()>(id_1, "increment", &())?;
     session.transact::<i16, ()>(id_2, "set", &0x12)?;
     let commit_2 = session.commit()?;
-    let mut session = vm.session(commit_2, SessionData::new())?;
+    let mut session = vm.session(SessionData::builder().base(commit_2))?;
     assert_eq!(session.query::<(), i64>(id_1, "read_value", &())?, 0xfe);
     assert_eq!(
         session.query::<_, Option<i16>>(id_2, "get", &())?,
         Some(0x12)
     );
 
-    let mut session = vm.session(commit_1, SessionData::new())?;
+    let mut session = vm.session(SessionData::builder().base(commit_1))?;
 
     // check if both modules' state was restored
     assert_eq!(session.query::<(), i64>(id_1, "read_value", &())?, 0xfd);
@@ -123,7 +123,7 @@ fn commit_restore_two_modules_session() -> Result<(), Error> {
 fn multiple_commits() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session(SessionData::new());
+    let mut session = vm.session(SessionData::builder())?;
     let id = session
         .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;
     // commit 1
@@ -132,20 +132,20 @@ fn multiple_commits() -> Result<(), Error> {
     let commit_1 = session.commit()?;
 
     // commit 2
-    let mut session = vm.session(commit_1, SessionData::new())?;
+    let mut session = vm.session(SessionData::builder().base(commit_1))?;
     assert_eq!(session.query::<(), i64>(id, "read_value", &())?, 0xfd);
     session.transact::<(), ()>(id, "increment", &())?;
     session.transact::<(), ()>(id, "increment", &())?;
     let commit_2 = session.commit()?;
-    let mut session = vm.session(commit_2, SessionData::new())?;
+    let mut session = vm.session(SessionData::builder().base(commit_2))?;
     assert_eq!(session.query::<(), i64>(id, "read_value", &())?, 0xff);
 
     // restore commit 1
-    let mut session = vm.session(commit_1, SessionData::new())?;
+    let mut session = vm.session(SessionData::builder().base(commit_1))?;
     assert_eq!(session.query::<(), i64>(id, "read_value", &())?, 0xfd);
 
     // restore commit 2
-    let mut session = vm.session(commit_2, SessionData::new())?;
+    let mut session = vm.session(SessionData::builder().base(commit_2))?;
     assert_eq!(session.query::<(), i64>(id, "read_value", &())?, 0xff);
     Ok(())
 }
@@ -165,7 +165,7 @@ fn increment_counter_and_commit(
 fn concurrent_sessions() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session(SessionData::new());
+    let mut session = vm.session(SessionData::builder())?;
     let counter = session
         .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;
 
@@ -181,7 +181,7 @@ fn concurrent_sessions() -> Result<(), Error> {
     const THREAD_NUM: usize = 6;
     let mut threads = Vec::with_capacity(THREAD_NUM);
     for n in 0..THREAD_NUM {
-        let session = vm.session(root, SessionData::new())?;
+        let session = vm.session(SessionData::builder().base(root))?;
         threads.push(thread::spawn(move || {
             increment_counter_and_commit(session, counter, n + 1)
         }));
@@ -213,7 +213,7 @@ fn concurrent_sessions() -> Result<(), Error> {
     const INCREMENTS_NUM: usize = 100;
     let mut threads = Vec::with_capacity(roots.len());
     for root in &roots {
-        let session = vm.session(*root, SessionData::new())?;
+        let session = vm.session(SessionData::builder().base(*root))?;
         threads.push(thread::spawn(move || {
             increment_counter_and_commit(session, counter, INCREMENTS_NUM)
         }));
@@ -252,7 +252,7 @@ fn concurrent_sessions() -> Result<(), Error> {
 fn squashing() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session(SessionData::new());
+    let mut session = vm.session(SessionData::builder())?;
     let counter = session
         .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;
 
@@ -260,15 +260,15 @@ fn squashing() -> Result<(), Error> {
 
     let genesis_root = session.commit()?;
 
-    let session = vm.session(genesis_root, SessionData::new())?;
+    let session = vm.session(SessionData::builder().base(genesis_root))?;
     let root_1 = increment_counter_and_commit(session, counter, 2)?;
 
-    let session = vm.session(root_1, SessionData::new())?;
+    let session = vm.session(SessionData::builder().base(root_1))?;
     let root_2 = increment_counter_and_commit(session, counter, 2)?;
 
     vm.squash_commit(root_1)?;
 
-    let session = vm.session(root_1, SessionData::new())?;
+    let session = vm.session(SessionData::builder().base(root_1))?;
     let root_3 = increment_counter_and_commit(session, counter, 2)?;
 
     assert_eq!(

--- a/piecrust/tests/constructor.rs
+++ b/piecrust/tests/constructor.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, DeployData, Error, VM};
+use piecrust::{module_bytecode, ModuleData, Error, VM};
 
 const CONTRACT_INIT_METHOD: &str = "init";
 const OWNER: [u8; 32] = [0u8; 32];
@@ -17,7 +17,7 @@ fn constructor() -> Result<(), Error> {
 
     let id = session.deploy(
         module_bytecode!("constructor"),
-        DeployData::builder(OWNER).constructor_arg(&0xabu8),
+        ModuleData::builder(OWNER).constructor_arg(&0xabu8),
     )?;
 
     assert_eq!(session.query::<(), u8>(id, "read_value", &())?, 0xab);
@@ -66,7 +66,7 @@ fn missing_init() -> Result<(), Error> {
 
     let result = session.deploy(
         module_bytecode!("counter"),
-        DeployData::builder(OWNER).constructor_arg(&0xabu8),
+        ModuleData::builder(OWNER).constructor_arg(&0xabu8),
     );
 
     assert!(

--- a/piecrust/tests/constructor.rs
+++ b/piecrust/tests/constructor.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, ModuleData, Error, VM};
+use piecrust::{module_bytecode, Error, ModuleData, VM};
 
 const CONTRACT_INIT_METHOD: &str = "init";
 const OWNER: [u8; 32] = [0u8; 32];

--- a/piecrust/tests/constructor.rs
+++ b/piecrust/tests/constructor.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, Error, ModuleData, VM};
+use piecrust::{module_bytecode, Error, ModuleData, SessionData, VM};
 
 const CONTRACT_INIT_METHOD: &str = "init";
 const OWNER: [u8; 32] = [0u8; 32];
@@ -13,7 +13,7 @@ const OWNER: [u8; 32] = [0u8; 32];
 fn constructor() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session();
+    let mut session = vm.genesis_session(SessionData::new());
 
     let id = session.deploy(
         module_bytecode!("constructor"),
@@ -44,7 +44,7 @@ fn constructor() -> Result<(), Error> {
 
     // initialized state should live through across session boundaries
     let commit_id = session.commit()?;
-    let mut session = vm.session(commit_id)?;
+    let mut session = vm.session(commit_id, SessionData::new())?;
     assert_eq!(session.query::<(), u8>(id, "read_value", &())?, 0xac);
 
     // not being able to call init directly should also be enforced across
@@ -62,7 +62,7 @@ fn constructor() -> Result<(), Error> {
 fn missing_init() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session();
+    let mut session = vm.genesis_session(SessionData::new());
 
     let result = session.deploy(
         module_bytecode!("counter"),

--- a/piecrust/tests/constructor.rs
+++ b/piecrust/tests/constructor.rs
@@ -13,7 +13,7 @@ const OWNER: [u8; 32] = [0u8; 32];
 fn constructor() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session(SessionData::new());
+    let mut session = vm.session(SessionData::builder())?;
 
     let id = session.deploy(
         module_bytecode!("constructor"),
@@ -44,7 +44,7 @@ fn constructor() -> Result<(), Error> {
 
     // initialized state should live through across session boundaries
     let commit_id = session.commit()?;
-    let mut session = vm.session(commit_id, SessionData::new())?;
+    let mut session = vm.session(SessionData::builder().base(commit_id))?;
     assert_eq!(session.query::<(), u8>(id, "read_value", &())?, 0xac);
 
     // not being able to call init directly should also be enforced across
@@ -62,7 +62,7 @@ fn constructor() -> Result<(), Error> {
 fn missing_init() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session(SessionData::new());
+    let mut session = vm.session(SessionData::builder())?;
 
     let result = session.deploy(
         module_bytecode!("counter"),

--- a/piecrust/tests/counter.rs
+++ b/piecrust/tests/counter.rs
@@ -12,7 +12,7 @@ const OWNER: [u8; 32] = [0u8; 32];
 fn counter_read_simple() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session(SessionData::new());
+    let mut session = vm.session(SessionData::builder())?;
 
     let id = session
         .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;
@@ -26,7 +26,7 @@ fn counter_read_simple() -> Result<(), Error> {
 fn counter_read_write_simple() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session(SessionData::new());
+    let mut session = vm.session(SessionData::builder())?;
 
     let id = session
         .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;

--- a/piecrust/tests/counter.rs
+++ b/piecrust/tests/counter.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, Error, ModuleData, VM};
+use piecrust::{module_bytecode, Error, ModuleData, SessionData, VM};
 
 const OWNER: [u8; 32] = [0u8; 32];
 
@@ -12,7 +12,7 @@ const OWNER: [u8; 32] = [0u8; 32];
 fn counter_read_simple() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session();
+    let mut session = vm.genesis_session(SessionData::new());
 
     let id = session
         .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;
@@ -26,7 +26,7 @@ fn counter_read_simple() -> Result<(), Error> {
 fn counter_read_write_simple() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session();
+    let mut session = vm.genesis_session(SessionData::new());
 
     let id = session
         .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;

--- a/piecrust/tests/counter.rs
+++ b/piecrust/tests/counter.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, ModuleData, Error, VM};
+use piecrust::{module_bytecode, Error, ModuleData, VM};
 
 const OWNER: [u8; 32] = [0u8; 32];
 

--- a/piecrust/tests/counter.rs
+++ b/piecrust/tests/counter.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, DeployData, Error, VM};
+use piecrust::{module_bytecode, ModuleData, Error, VM};
 
 const OWNER: [u8; 32] = [0u8; 32];
 
@@ -15,7 +15,7 @@ fn counter_read_simple() -> Result<(), Error> {
     let mut session = vm.genesis_session();
 
     let id = session
-        .deploy(module_bytecode!("counter"), DeployData::builder(OWNER))?;
+        .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;
 
     assert_eq!(session.query::<(), i64>(id, "read_value", &())?, 0xfc);
 
@@ -29,7 +29,7 @@ fn counter_read_write_simple() -> Result<(), Error> {
     let mut session = vm.genesis_session();
 
     let id = session
-        .deploy(module_bytecode!("counter"), DeployData::builder(OWNER))?;
+        .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;
 
     assert_eq!(session.query::<(), i64>(id, "read_value", &())?, 0xfc);
 

--- a/piecrust/tests/crossover.rs
+++ b/piecrust/tests/crossover.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, Error, ModuleData, VM};
+use piecrust::{module_bytecode, Error, ModuleData, SessionData, VM};
 use piecrust_uplink::ModuleId;
 
 const OWNER: [u8; 32] = [0u8; 32];
@@ -25,7 +25,7 @@ const CROSSOVER_TWO: ModuleId = {
 fn crossover() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session();
+    let mut session = vm.genesis_session(SessionData::new());
     session.set_point_limit(u64::MAX / 100);
 
     session.deploy(

--- a/piecrust/tests/crossover.rs
+++ b/piecrust/tests/crossover.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, DeployData, Error, VM};
+use piecrust::{module_bytecode, ModuleData, Error, VM};
 use piecrust_uplink::ModuleId;
 
 const OWNER: [u8; 32] = [0u8; 32];
@@ -30,11 +30,11 @@ fn crossover() -> Result<(), Error> {
 
     session.deploy(
         module_bytecode!("crossover"),
-        DeployData::builder(OWNER).module_id(CROSSOVER_ONE),
+        ModuleData::builder(OWNER).module_id(CROSSOVER_ONE),
     )?;
     session.deploy(
         module_bytecode!("crossover"),
-        DeployData::builder(OWNER).module_id(CROSSOVER_TWO),
+        ModuleData::builder(OWNER).module_id(CROSSOVER_TWO),
     )?;
 
     // These value should not be set to `INITIAL_VALUE` in the contract.

--- a/piecrust/tests/crossover.rs
+++ b/piecrust/tests/crossover.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, ModuleData, Error, VM};
+use piecrust::{module_bytecode, Error, ModuleData, VM};
 use piecrust_uplink::ModuleId;
 
 const OWNER: [u8; 32] = [0u8; 32];

--- a/piecrust/tests/crossover.rs
+++ b/piecrust/tests/crossover.rs
@@ -25,7 +25,7 @@ const CROSSOVER_TWO: ModuleId = {
 fn crossover() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session(SessionData::new());
+    let mut session = vm.session(SessionData::builder())?;
     session.set_point_limit(u64::MAX / 100);
 
     session.deploy(

--- a/piecrust/tests/debugger.rs
+++ b/piecrust/tests/debugger.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, DeployData, Error, VM};
+use piecrust::{module_bytecode, ModuleData, Error, VM};
 
 const OWNER: [u8; 32] = [0u8; 32];
 
@@ -15,7 +15,7 @@ pub fn debug() -> Result<(), Error> {
     let mut session = vm.genesis_session();
 
     let id = session
-        .deploy(module_bytecode!("debugger"), DeployData::builder(OWNER))?;
+        .deploy(module_bytecode!("debugger"), ModuleData::builder(OWNER))?;
 
     session.query(id, "debug", &String::from("Hello world"))?;
 

--- a/piecrust/tests/debugger.rs
+++ b/piecrust/tests/debugger.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, Error, ModuleData, VM};
+use piecrust::{module_bytecode, Error, ModuleData, SessionData, VM};
 
 const OWNER: [u8; 32] = [0u8; 32];
 
@@ -12,7 +12,7 @@ const OWNER: [u8; 32] = [0u8; 32];
 pub fn debug() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session();
+    let mut session = vm.genesis_session(SessionData::new());
 
     let id = session
         .deploy(module_bytecode!("debugger"), ModuleData::builder(OWNER))?;

--- a/piecrust/tests/debugger.rs
+++ b/piecrust/tests/debugger.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, ModuleData, Error, VM};
+use piecrust::{module_bytecode, Error, ModuleData, VM};
 
 const OWNER: [u8; 32] = [0u8; 32];
 

--- a/piecrust/tests/debugger.rs
+++ b/piecrust/tests/debugger.rs
@@ -12,7 +12,7 @@ const OWNER: [u8; 32] = [0u8; 32];
 pub fn debug() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session(SessionData::new());
+    let mut session = vm.session(SessionData::builder())?;
 
     let id = session
         .deploy(module_bytecode!("debugger"), ModuleData::builder(OWNER))?;

--- a/piecrust/tests/deploy_with_id.rs
+++ b/piecrust/tests/deploy_with_id.rs
@@ -16,7 +16,7 @@ pub fn deploy_with_id() -> Result<(), Error> {
     let bytecode = module_bytecode!("counter");
     let some_id = [1u8; 32];
     let module_id = ModuleId::from(some_id);
-    let mut session = vm.genesis_session(SessionData::new());
+    let mut session = vm.session(SessionData::builder())?;
     session
         .deploy(bytecode, ModuleData::builder(OWNER).module_id(module_id))?;
 

--- a/piecrust/tests/deploy_with_id.rs
+++ b/piecrust/tests/deploy_with_id.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, Error, ModuleData, VM};
+use piecrust::{module_bytecode, Error, ModuleData, SessionData, VM};
 use piecrust_uplink::ModuleId;
 
 const OWNER: [u8; 32] = [0u8; 32];
@@ -16,7 +16,7 @@ pub fn deploy_with_id() -> Result<(), Error> {
     let bytecode = module_bytecode!("counter");
     let some_id = [1u8; 32];
     let module_id = ModuleId::from(some_id);
-    let mut session = vm.genesis_session();
+    let mut session = vm.genesis_session(SessionData::new());
     session
         .deploy(bytecode, ModuleData::builder(OWNER).module_id(module_id))?;
 

--- a/piecrust/tests/deploy_with_id.rs
+++ b/piecrust/tests/deploy_with_id.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, ModuleData, Error, VM};
+use piecrust::{module_bytecode, Error, ModuleData, VM};
 use piecrust_uplink::ModuleId;
 
 const OWNER: [u8; 32] = [0u8; 32];

--- a/piecrust/tests/deploy_with_id.rs
+++ b/piecrust/tests/deploy_with_id.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, DeployData, Error, VM};
+use piecrust::{module_bytecode, ModuleData, Error, VM};
 use piecrust_uplink::ModuleId;
 
 const OWNER: [u8; 32] = [0u8; 32];
@@ -18,7 +18,7 @@ pub fn deploy_with_id() -> Result<(), Error> {
     let module_id = ModuleId::from(some_id);
     let mut session = vm.genesis_session();
     session
-        .deploy(bytecode, DeployData::builder(OWNER).module_id(module_id))?;
+        .deploy(bytecode, ModuleData::builder(OWNER).module_id(module_id))?;
 
     assert_eq!(
         session.query::<(), i64>(module_id, "read_value", &())?,

--- a/piecrust/tests/eventer.rs
+++ b/piecrust/tests/eventer.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, DeployData, Error, VM};
+use piecrust::{module_bytecode, ModuleData, Error, VM};
 
 const OWNER: [u8; 32] = [0u8; 32];
 
@@ -15,7 +15,7 @@ pub fn vm_center_events() -> Result<(), Error> {
     let mut session = vm.genesis_session();
 
     let eventer_id = session
-        .deploy(module_bytecode!("eventer"), DeployData::builder(OWNER))?;
+        .deploy(module_bytecode!("eventer"), ModuleData::builder(OWNER))?;
 
     const EVENT_NUM: u32 = 5;
 

--- a/piecrust/tests/eventer.rs
+++ b/piecrust/tests/eventer.rs
@@ -12,7 +12,7 @@ const OWNER: [u8; 32] = [0u8; 32];
 pub fn vm_center_events() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session(SessionData::new());
+    let mut session = vm.session(SessionData::builder())?;
 
     let eventer_id = session
         .deploy(module_bytecode!("eventer"), ModuleData::builder(OWNER))?;

--- a/piecrust/tests/eventer.rs
+++ b/piecrust/tests/eventer.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, ModuleData, Error, VM};
+use piecrust::{module_bytecode, Error, ModuleData, VM};
 
 const OWNER: [u8; 32] = [0u8; 32];
 

--- a/piecrust/tests/eventer.rs
+++ b/piecrust/tests/eventer.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, Error, ModuleData, VM};
+use piecrust::{module_bytecode, Error, ModuleData, SessionData, VM};
 
 const OWNER: [u8; 32] = [0u8; 32];
 
@@ -12,7 +12,7 @@ const OWNER: [u8; 32] = [0u8; 32];
 pub fn vm_center_events() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session();
+    let mut session = vm.genesis_session(SessionData::new());
 
     let eventer_id = session
         .deploy(module_bytecode!("eventer"), ModuleData::builder(OWNER))?;

--- a/piecrust/tests/everest.rs
+++ b/piecrust/tests/everest.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, DeployData, Error, VM};
+use piecrust::{module_bytecode, ModuleData, Error, VM};
 
 const OWNER: [u8; 32] = [0u8; 32];
 
@@ -15,7 +15,7 @@ pub fn height() -> Result<(), Error> {
     let mut session = vm.genesis_session();
 
     let id = session
-        .deploy(module_bytecode!("everest"), DeployData::builder(OWNER))?;
+        .deploy(module_bytecode!("everest"), ModuleData::builder(OWNER))?;
 
     for h in 0u64..1024 {
         session.set_meta("height", h);
@@ -30,7 +30,7 @@ pub fn meta_data_optionality() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
     let mut session = vm.genesis_session();
     let id = session
-        .deploy(module_bytecode!("everest"), DeployData::builder(OWNER))?;
+        .deploy(module_bytecode!("everest"), ModuleData::builder(OWNER))?;
     let height: Option<u64> = session.transact(id, "get_height", &())?;
     assert!(height.is_none());
     Ok(())

--- a/piecrust/tests/everest.rs
+++ b/piecrust/tests/everest.rs
@@ -12,19 +12,19 @@ const OWNER: [u8; 32] = [0u8; 32];
 pub fn height() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session(SessionData::new());
+    const HEIGHT: u64 = 384u64;
+    let mut session =
+        vm.genesis_session(SessionData::new().insert("height", HEIGHT));
 
     let id = session
         .deploy(module_bytecode!("everest"), ModuleData::builder(OWNER))?;
 
-    for h in 0u64..1024 {
-        session.set_meta("height", h);
-        let height: Option<u64> = session.transact(id, "get_height", &())?;
-        assert_eq!(height.unwrap(), h);
-    }
+    let height: Option<u64> = session.transact(id, "get_height", &())?;
+    assert_eq!(height.unwrap(), HEIGHT);
 
     Ok(())
 }
+
 #[test]
 pub fn meta_data_optionality() -> Result<(), Error> {
     let vm = VM::ephemeral()?;

--- a/piecrust/tests/everest.rs
+++ b/piecrust/tests/everest.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, Error, ModuleData, VM};
+use piecrust::{module_bytecode, Error, ModuleData, SessionData, VM};
 
 const OWNER: [u8; 32] = [0u8; 32];
 
@@ -12,7 +12,7 @@ const OWNER: [u8; 32] = [0u8; 32];
 pub fn height() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session();
+    let mut session = vm.genesis_session(SessionData::new());
 
     let id = session
         .deploy(module_bytecode!("everest"), ModuleData::builder(OWNER))?;
@@ -28,7 +28,7 @@ pub fn height() -> Result<(), Error> {
 #[test]
 pub fn meta_data_optionality() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
-    let mut session = vm.genesis_session();
+    let mut session = vm.genesis_session(SessionData::new());
     let id = session
         .deploy(module_bytecode!("everest"), ModuleData::builder(OWNER))?;
     let height: Option<u64> = session.transact(id, "get_height", &())?;

--- a/piecrust/tests/everest.rs
+++ b/piecrust/tests/everest.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, ModuleData, Error, VM};
+use piecrust::{module_bytecode, Error, ModuleData, VM};
 
 const OWNER: [u8; 32] = [0u8; 32];
 

--- a/piecrust/tests/everest.rs
+++ b/piecrust/tests/everest.rs
@@ -14,7 +14,7 @@ pub fn height() -> Result<(), Error> {
 
     const HEIGHT: u64 = 384u64;
     let mut session =
-        vm.genesis_session(SessionData::new().insert("height", HEIGHT));
+        vm.session(SessionData::builder().insert("height", HEIGHT))?;
 
     let id = session
         .deploy(module_bytecode!("everest"), ModuleData::builder(OWNER))?;
@@ -28,7 +28,7 @@ pub fn height() -> Result<(), Error> {
 #[test]
 pub fn meta_data_optionality() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
-    let mut session = vm.genesis_session(SessionData::new());
+    let mut session = vm.session(SessionData::builder())?;
     let id = session
         .deploy(module_bytecode!("everest"), ModuleData::builder(OWNER))?;
     let height: Option<u64> = session.transact(id, "get_height", &())?;

--- a/piecrust/tests/everest.rs
+++ b/piecrust/tests/everest.rs
@@ -12,7 +12,7 @@ const OWNER: [u8; 32] = [0u8; 32];
 pub fn height() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    const HEIGHT: u64 = 384u64;
+    const HEIGHT: u64 = 29_000u64;
     let mut session =
         vm.session(SessionData::builder().insert("height", HEIGHT))?;
 

--- a/piecrust/tests/fallible_counter.rs
+++ b/piecrust/tests/fallible_counter.rs
@@ -13,7 +13,7 @@ const OWNER: [u8; 32] = [0u8; 32];
 fn fallible_read_write_panic() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session(SessionData::new());
+    let mut session = vm.session(SessionData::builder())?;
 
     let id = session.deploy(
         module_bytecode!("fallible_counter"),

--- a/piecrust/tests/fallible_counter.rs
+++ b/piecrust/tests/fallible_counter.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, DeployData, Error, VM};
+use piecrust::{module_bytecode, ModuleData, Error, VM};
 
 const OWNER: [u8; 32] = [0u8; 32];
 
@@ -17,7 +17,7 @@ fn fallible_read_write_panic() -> Result<(), Error> {
 
     let id = session.deploy(
         module_bytecode!("fallible_counter"),
-        DeployData::builder(OWNER),
+        ModuleData::builder(OWNER),
     )?;
 
     session.transact::<bool, ()>(id, "increment", &false)?;

--- a/piecrust/tests/fallible_counter.rs
+++ b/piecrust/tests/fallible_counter.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, Error, ModuleData, VM};
+use piecrust::{module_bytecode, Error, ModuleData, SessionData, VM};
 
 const OWNER: [u8; 32] = [0u8; 32];
 
@@ -13,7 +13,7 @@ const OWNER: [u8; 32] = [0u8; 32];
 fn fallible_read_write_panic() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session();
+    let mut session = vm.genesis_session(SessionData::new());
 
     let id = session.deploy(
         module_bytecode!("fallible_counter"),

--- a/piecrust/tests/fallible_counter.rs
+++ b/piecrust/tests/fallible_counter.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, ModuleData, Error, VM};
+use piecrust::{module_bytecode, Error, ModuleData, VM};
 
 const OWNER: [u8; 32] = [0u8; 32];
 

--- a/piecrust/tests/fibonacci.rs
+++ b/piecrust/tests/fibonacci.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, Error, ModuleData, VM};
+use piecrust::{module_bytecode, Error, ModuleData, SessionData, VM};
 
 const OWNER: [u8; 32] = [0u8; 32];
 
@@ -12,7 +12,7 @@ const OWNER: [u8; 32] = [0u8; 32];
 pub fn fibo() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session();
+    let mut session = vm.genesis_session(SessionData::new());
 
     let id = session
         .deploy(module_bytecode!("fibonacci"), ModuleData::builder(OWNER))?;

--- a/piecrust/tests/fibonacci.rs
+++ b/piecrust/tests/fibonacci.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, DeployData, Error, VM};
+use piecrust::{module_bytecode, ModuleData, Error, VM};
 
 const OWNER: [u8; 32] = [0u8; 32];
 
@@ -15,7 +15,7 @@ pub fn fibo() -> Result<(), Error> {
     let mut session = vm.genesis_session();
 
     let id = session
-        .deploy(module_bytecode!("fibonacci"), DeployData::builder(OWNER))?;
+        .deploy(module_bytecode!("fibonacci"), ModuleData::builder(OWNER))?;
 
     assert_eq!(session.query::<u32, u64>(id, "nth", &0)?, 1);
     assert_eq!(session.query::<u32, u64>(id, "nth", &1)?, 1);

--- a/piecrust/tests/fibonacci.rs
+++ b/piecrust/tests/fibonacci.rs
@@ -12,7 +12,7 @@ const OWNER: [u8; 32] = [0u8; 32];
 pub fn fibo() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session(SessionData::new());
+    let mut session = vm.session(SessionData::builder())?;
 
     let id = session
         .deploy(module_bytecode!("fibonacci"), ModuleData::builder(OWNER))?;

--- a/piecrust/tests/fibonacci.rs
+++ b/piecrust/tests/fibonacci.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, ModuleData, Error, VM};
+use piecrust::{module_bytecode, Error, ModuleData, VM};
 
 const OWNER: [u8; 32] = [0u8; 32];
 

--- a/piecrust/tests/host.rs
+++ b/piecrust/tests/host.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, ModuleData, Error, VM};
+use piecrust::{module_bytecode, Error, ModuleData, VM};
 use rkyv::Deserialize;
 
 const OWNER: [u8; 32] = [0u8; 32];

--- a/piecrust/tests/host.rs
+++ b/piecrust/tests/host.rs
@@ -24,7 +24,7 @@ pub fn host_hash() -> Result<(), Error> {
     let mut vm = VM::ephemeral()?;
     vm.register_host_query("hash", hash);
 
-    let mut session = vm.genesis_session(SessionData::new());
+    let mut session = vm.session(SessionData::builder())?;
 
     let id =
         session.deploy(module_bytecode!("host"), ModuleData::builder(OWNER))?;

--- a/piecrust/tests/host.rs
+++ b/piecrust/tests/host.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, DeployData, Error, VM};
+use piecrust::{module_bytecode, ModuleData, Error, VM};
 use rkyv::Deserialize;
 
 const OWNER: [u8; 32] = [0u8; 32];
@@ -27,7 +27,7 @@ pub fn host_hash() -> Result<(), Error> {
     let mut session = vm.genesis_session();
 
     let id =
-        session.deploy(module_bytecode!("host"), DeployData::builder(OWNER))?;
+        session.deploy(module_bytecode!("host"), ModuleData::builder(OWNER))?;
 
     let v = vec![0u8, 1, 2];
     let h = session

--- a/piecrust/tests/host.rs
+++ b/piecrust/tests/host.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, Error, ModuleData, VM};
+use piecrust::{module_bytecode, Error, ModuleData, SessionData, VM};
 use rkyv::Deserialize;
 
 const OWNER: [u8; 32] = [0u8; 32];
@@ -24,7 +24,7 @@ pub fn host_hash() -> Result<(), Error> {
     let mut vm = VM::ephemeral()?;
     vm.register_host_query("hash", hash);
 
-    let mut session = vm.genesis_session();
+    let mut session = vm.genesis_session(SessionData::new());
 
     let id =
         session.deploy(module_bytecode!("host"), ModuleData::builder(OWNER))?;

--- a/piecrust/tests/metadata.rs
+++ b/piecrust/tests/metadata.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, ModuleData, Error, VM};
+use piecrust::{module_bytecode, Error, ModuleData, VM};
 use piecrust_uplink::ModuleId;
 
 #[test]

--- a/piecrust/tests/metadata.rs
+++ b/piecrust/tests/metadata.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, DeployData, Error, VM};
+use piecrust::{module_bytecode, ModuleData, Error, VM};
 use piecrust_uplink::ModuleId;
 
 #[test]
@@ -17,7 +17,7 @@ fn metadata() -> Result<(), Error> {
 
     let id = session.deploy(
         module_bytecode!("metadata"),
-        DeployData::builder(EXPECTED_OWNER),
+        ModuleData::builder(EXPECTED_OWNER),
     )?;
 
     // owner should be available after deployment

--- a/piecrust/tests/metadata.rs
+++ b/piecrust/tests/metadata.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, Error, ModuleData, VM};
+use piecrust::{module_bytecode, Error, ModuleData, SessionData, VM};
 use piecrust_uplink::ModuleId;
 
 #[test]
@@ -13,7 +13,7 @@ fn metadata() -> Result<(), Error> {
 
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session();
+    let mut session = vm.genesis_session(SessionData::new());
 
     let id = session.deploy(
         module_bytecode!("metadata"),
@@ -28,7 +28,7 @@ fn metadata() -> Result<(), Error> {
 
     // owner should live across session boundaries
     let commit_id = session.commit()?;
-    let mut session = vm.session(commit_id)?;
+    let mut session = vm.session(commit_id, SessionData::new())?;
     let owner = session.query::<(), [u8; 32]>(id, "read_owner", &())?;
     let self_id = session.query::<(), ModuleId>(id, "read_id", &())?;
     assert_eq!(owner, EXPECTED_OWNER);

--- a/piecrust/tests/metadata.rs
+++ b/piecrust/tests/metadata.rs
@@ -13,7 +13,7 @@ fn metadata() -> Result<(), Error> {
 
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session(SessionData::new());
+    let mut session = vm.session(SessionData::builder())?;
 
     let id = session.deploy(
         module_bytecode!("metadata"),
@@ -28,7 +28,7 @@ fn metadata() -> Result<(), Error> {
 
     // owner should live across session boundaries
     let commit_id = session.commit()?;
-    let mut session = vm.session(commit_id, SessionData::new())?;
+    let mut session = vm.session(SessionData::builder().base(commit_id))?;
     let owner = session.query::<(), [u8; 32]>(id, "read_owner", &())?;
     let self_id = session.query::<(), ModuleId>(id, "read_id", &())?;
     assert_eq!(owner, EXPECTED_OWNER);

--- a/piecrust/tests/persistence.rs
+++ b/piecrust/tests/persistence.rs
@@ -17,7 +17,7 @@ fn session_commits_persistence() -> Result<(), Error> {
 
     let commit_1;
     {
-        let mut session = vm.genesis_session(SessionData::new());
+        let mut session = vm.session(SessionData::builder())?;
         id_1 = session
             .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;
         id_2 = session
@@ -35,7 +35,7 @@ fn session_commits_persistence() -> Result<(), Error> {
 
     let commit_2;
     {
-        let mut session = vm.session(commit_1, SessionData::new())?;
+        let mut session = vm.session(SessionData::builder().base(commit_1))?;
 
         session.transact::<(), ()>(id_1, "increment", &())?;
         session.transact::<i16, ()>(id_2, "set", &0x12)?;
@@ -49,7 +49,7 @@ fn session_commits_persistence() -> Result<(), Error> {
 
     {
         let vm2 = VM::new(vm.root_dir())?;
-        let mut session = vm2.session(commit_1, SessionData::new())?;
+        let mut session = vm2.session(SessionData::builder().base(commit_1))?;
 
         // check if both modules' state was restored
         assert_eq!(session.query::<(), i64>(id_1, "read_value", &())?, 0xfd);
@@ -61,7 +61,7 @@ fn session_commits_persistence() -> Result<(), Error> {
 
     {
         let vm3 = VM::new(vm.root_dir())?;
-        let mut session = vm3.session(commit_2, SessionData::new())?;
+        let mut session = vm3.session(SessionData::builder().base(commit_2))?;
 
         // check if both modules' state was restored
         assert_eq!(session.query::<(), i64>(id_1, "read_value", &())?, 0xfe);
@@ -76,7 +76,7 @@ fn session_commits_persistence() -> Result<(), Error> {
 #[test]
 fn modules_persistence() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
-    let mut session = vm.genesis_session(SessionData::new());
+    let mut session = vm.session(SessionData::builder())?;
     let id_1 = session
         .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;
     let id_2 =
@@ -93,7 +93,7 @@ fn modules_persistence() -> Result<(), Error> {
     let commit_1 = session.commit()?;
 
     let vm2 = VM::new(vm.root_dir())?;
-    let mut session2 = vm2.session(commit_1, SessionData::new())?;
+    let mut session2 = vm2.session(SessionData::builder().base(commit_1))?;
 
     // check if both modules' state was restored
     assert_eq!(session2.query::<(), i64>(id_1, "read_value", &())?, 0xfd);

--- a/piecrust/tests/persistence.rs
+++ b/piecrust/tests/persistence.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, DeployData, Error, VM};
+use piecrust::{module_bytecode, ModuleData, Error, VM};
 
 const OWNER: [u8; 32] = [0u8; 32];
 
@@ -19,9 +19,9 @@ fn session_commits_persistence() -> Result<(), Error> {
     {
         let mut session = vm.genesis_session();
         id_1 = session
-            .deploy(module_bytecode!("counter"), DeployData::builder(OWNER))?;
+            .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;
         id_2 = session
-            .deploy(module_bytecode!("box"), DeployData::builder(OWNER))?;
+            .deploy(module_bytecode!("box"), ModuleData::builder(OWNER))?;
 
         session.transact::<(), ()>(id_1, "increment", &())?;
         session.transact::<i16, ()>(id_2, "set", &0x11)?;
@@ -78,9 +78,9 @@ fn modules_persistence() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
     let mut session = vm.genesis_session();
     let id_1 = session
-        .deploy(module_bytecode!("counter"), DeployData::builder(OWNER))?;
+        .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;
     let id_2 =
-        session.deploy(module_bytecode!("box"), DeployData::builder(OWNER))?;
+        session.deploy(module_bytecode!("box"), ModuleData::builder(OWNER))?;
 
     session.transact::<(), ()>(id_1, "increment", &())?;
     session.transact::<i16, ()>(id_2, "set", &0x11)?;

--- a/piecrust/tests/persistence.rs
+++ b/piecrust/tests/persistence.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, ModuleData, Error, VM};
+use piecrust::{module_bytecode, Error, ModuleData, VM};
 
 const OWNER: [u8; 32] = [0u8; 32];
 

--- a/piecrust/tests/root.rs
+++ b/piecrust/tests/root.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, DeployData, Error, VM};
+use piecrust::{module_bytecode, ModuleData, Error, VM};
 
 const OWNER: [u8; 32] = [0u8; 32];
 
@@ -13,7 +13,7 @@ pub fn state_root_calculation() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
     let mut session = vm.genesis_session();
     let id_1 = session
-        .deploy(module_bytecode!("counter"), DeployData::builder(OWNER))?;
+        .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;
 
     session.transact::<(), ()>(id_1, "increment", &())?;
 
@@ -27,7 +27,7 @@ pub fn state_root_calculation() -> Result<(), Error> {
 
     let mut session = vm.session(commit_1)?;
     let id_2 =
-        session.deploy(module_bytecode!("box"), DeployData::builder(OWNER))?;
+        session.deploy(module_bytecode!("box"), ModuleData::builder(OWNER))?;
     session.transact::<i16, ()>(id_2, "set", &0x11)?;
     session.transact::<(), ()>(id_1, "increment", &())?;
 

--- a/piecrust/tests/root.rs
+++ b/piecrust/tests/root.rs
@@ -11,7 +11,7 @@ const OWNER: [u8; 32] = [0u8; 32];
 #[test]
 pub fn state_root_calculation() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
-    let mut session = vm.genesis_session(SessionData::new());
+    let mut session = vm.session(SessionData::builder())?;
     let id_1 = session
         .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;
 
@@ -25,7 +25,7 @@ pub fn state_root_calculation() -> Result<(), Error> {
         "The commit root is the same as the state root"
     );
 
-    let mut session = vm.session(commit_1, SessionData::new())?;
+    let mut session = vm.session(SessionData::builder().base(commit_1))?;
     let id_2 =
         session.deploy(module_bytecode!("box"), ModuleData::builder(OWNER))?;
     session.transact::<i16, ()>(id_2, "set", &0x11)?;
@@ -43,7 +43,7 @@ pub fn state_root_calculation() -> Result<(), Error> {
         "The state root should change since the state changes"
     );
 
-    let session = vm.session(commit_2, SessionData::new())?;
+    let session = vm.session(SessionData::builder().base(commit_2))?;
     let root_3 = session.root();
 
     assert_eq!(root_2, root_3, "The root of a session should be the same if no modifications were made");

--- a/piecrust/tests/root.rs
+++ b/piecrust/tests/root.rs
@@ -4,14 +4,14 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, Error, ModuleData, VM};
+use piecrust::{module_bytecode, Error, ModuleData, SessionData, VM};
 
 const OWNER: [u8; 32] = [0u8; 32];
 
 #[test]
 pub fn state_root_calculation() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
-    let mut session = vm.genesis_session();
+    let mut session = vm.genesis_session(SessionData::new());
     let id_1 = session
         .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;
 
@@ -25,7 +25,7 @@ pub fn state_root_calculation() -> Result<(), Error> {
         "The commit root is the same as the state root"
     );
 
-    let mut session = vm.session(commit_1)?;
+    let mut session = vm.session(commit_1, SessionData::new())?;
     let id_2 =
         session.deploy(module_bytecode!("box"), ModuleData::builder(OWNER))?;
     session.transact::<i16, ()>(id_2, "set", &0x11)?;
@@ -43,7 +43,7 @@ pub fn state_root_calculation() -> Result<(), Error> {
         "The state root should change since the state changes"
     );
 
-    let session = vm.session(commit_2)?;
+    let session = vm.session(commit_2, SessionData::new())?;
     let root_3 = session.root();
 
     assert_eq!(root_2, root_3, "The root of a session should be the same if no modifications were made");

--- a/piecrust/tests/root.rs
+++ b/piecrust/tests/root.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, ModuleData, Error, VM};
+use piecrust::{module_bytecode, Error, ModuleData, VM};
 
 const OWNER: [u8; 32] = [0u8; 32];
 

--- a/piecrust/tests/spender.rs
+++ b/piecrust/tests/spender.rs
@@ -12,7 +12,7 @@ const OWNER: [u8; 32] = [0u8; 32];
 pub fn points_get_used() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session(SessionData::new());
+    let mut session = vm.session(SessionData::builder())?;
 
     let counter_id = session
         .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;
@@ -34,7 +34,7 @@ pub fn points_get_used() -> Result<(), Error> {
 pub fn fails_with_out_of_points() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session(SessionData::new());
+    let mut session = vm.session(SessionData::builder())?;
 
     let counter_id = session
         .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;
@@ -56,7 +56,7 @@ pub fn limit_and_spent() -> Result<(), Error> {
 
     const LIMIT: u64 = 10000;
 
-    let mut session = vm.genesis_session(SessionData::new());
+    let mut session = vm.session(SessionData::builder())?;
 
     let spender_id = session
         .deploy(module_bytecode!("spender"), ModuleData::builder(OWNER))?;

--- a/piecrust/tests/spender.rs
+++ b/piecrust/tests/spender.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, Error, ModuleData, VM};
+use piecrust::{module_bytecode, Error, ModuleData, SessionData, VM};
 
 const OWNER: [u8; 32] = [0u8; 32];
 
@@ -12,7 +12,7 @@ const OWNER: [u8; 32] = [0u8; 32];
 pub fn points_get_used() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session();
+    let mut session = vm.genesis_session(SessionData::new());
 
     let counter_id = session
         .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;
@@ -34,7 +34,7 @@ pub fn points_get_used() -> Result<(), Error> {
 pub fn fails_with_out_of_points() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session();
+    let mut session = vm.genesis_session(SessionData::new());
 
     let counter_id = session
         .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;
@@ -56,7 +56,7 @@ pub fn limit_and_spent() -> Result<(), Error> {
 
     const LIMIT: u64 = 10000;
 
-    let mut session = vm.genesis_session();
+    let mut session = vm.genesis_session(SessionData::new());
 
     let spender_id = session
         .deploy(module_bytecode!("spender"), ModuleData::builder(OWNER))?;

--- a/piecrust/tests/spender.rs
+++ b/piecrust/tests/spender.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, DeployData, Error, VM};
+use piecrust::{module_bytecode, ModuleData, Error, VM};
 
 const OWNER: [u8; 32] = [0u8; 32];
 
@@ -15,9 +15,9 @@ pub fn points_get_used() -> Result<(), Error> {
     let mut session = vm.genesis_session();
 
     let counter_id = session
-        .deploy(module_bytecode!("counter"), DeployData::builder(OWNER))?;
+        .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;
     let center_id = session
-        .deploy(module_bytecode!("callcenter"), DeployData::builder(OWNER))?;
+        .deploy(module_bytecode!("callcenter"), ModuleData::builder(OWNER))?;
 
     session.query::<_, i64>(counter_id, "read_value", &())?;
     let counter_spent = session.spent();
@@ -37,7 +37,7 @@ pub fn fails_with_out_of_points() -> Result<(), Error> {
     let mut session = vm.genesis_session();
 
     let counter_id = session
-        .deploy(module_bytecode!("counter"), DeployData::builder(OWNER))?;
+        .deploy(module_bytecode!("counter"), ModuleData::builder(OWNER))?;
 
     session.set_point_limit(0);
 
@@ -59,7 +59,7 @@ pub fn limit_and_spent() -> Result<(), Error> {
     let mut session = vm.genesis_session();
 
     let spender_id = session
-        .deploy(module_bytecode!("spender"), DeployData::builder(OWNER))?;
+        .deploy(module_bytecode!("spender"), ModuleData::builder(OWNER))?;
 
     session.set_point_limit(LIMIT);
 

--- a/piecrust/tests/spender.rs
+++ b/piecrust/tests/spender.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, ModuleData, Error, VM};
+use piecrust::{module_bytecode, Error, ModuleData, VM};
 
 const OWNER: [u8; 32] = [0u8; 32];
 

--- a/piecrust/tests/stack.rs
+++ b/piecrust/tests/stack.rs
@@ -12,7 +12,7 @@ const OWNER: [u8; 32] = [0u8; 32];
 pub fn push_pop() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session(SessionData::new());
+    let mut session = vm.session(SessionData::builder())?;
 
     let id = session
         .deploy(module_bytecode!("stack"), ModuleData::builder(OWNER))?;
@@ -37,7 +37,7 @@ pub fn push_pop() -> Result<(), Error> {
 pub fn multi_push_pop() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session(SessionData::new());
+    let mut session = vm.session(SessionData::builder())?;
 
     let id = session
         .deploy(module_bytecode!("stack"), ModuleData::builder(OWNER))?;

--- a/piecrust/tests/stack.rs
+++ b/piecrust/tests/stack.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, ModuleData, Error, VM};
+use piecrust::{module_bytecode, Error, ModuleData, VM};
 
 const OWNER: [u8; 32] = [0u8; 32];
 

--- a/piecrust/tests/stack.rs
+++ b/piecrust/tests/stack.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, DeployData, Error, VM};
+use piecrust::{module_bytecode, ModuleData, Error, VM};
 
 const OWNER: [u8; 32] = [0u8; 32];
 
@@ -15,7 +15,7 @@ pub fn push_pop() -> Result<(), Error> {
     let mut session = vm.genesis_session();
 
     let id = session
-        .deploy(module_bytecode!("stack"), DeployData::builder(OWNER))?;
+        .deploy(module_bytecode!("stack"), ModuleData::builder(OWNER))?;
 
     let val = 42;
 
@@ -40,7 +40,7 @@ pub fn multi_push_pop() -> Result<(), Error> {
     let mut session = vm.genesis_session();
 
     let id = session
-        .deploy(module_bytecode!("stack"), DeployData::builder(OWNER))?;
+        .deploy(module_bytecode!("stack"), ModuleData::builder(OWNER))?;
 
     const N: i32 = 16;
 

--- a/piecrust/tests/stack.rs
+++ b/piecrust/tests/stack.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, Error, ModuleData, VM};
+use piecrust::{module_bytecode, Error, ModuleData, SessionData, VM};
 
 const OWNER: [u8; 32] = [0u8; 32];
 
@@ -12,7 +12,7 @@ const OWNER: [u8; 32] = [0u8; 32];
 pub fn push_pop() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session();
+    let mut session = vm.genesis_session(SessionData::new());
 
     let id = session
         .deploy(module_bytecode!("stack"), ModuleData::builder(OWNER))?;
@@ -37,7 +37,7 @@ pub fn push_pop() -> Result<(), Error> {
 pub fn multi_push_pop() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session();
+    let mut session = vm.genesis_session(SessionData::new());
 
     let id = session
         .deploy(module_bytecode!("stack"), ModuleData::builder(OWNER))?;

--- a/piecrust/tests/vector.rs
+++ b/piecrust/tests/vector.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, Error, ModuleData, VM};
+use piecrust::{module_bytecode, Error, ModuleData, SessionData, VM};
 
 const OWNER: [u8; 32] = [0u8; 32];
 
@@ -12,7 +12,7 @@ const OWNER: [u8; 32] = [0u8; 32];
 pub fn vector_push_pop() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session();
+    let mut session = vm.genesis_session(SessionData::new());
 
     let id = session
         .deploy(module_bytecode!("vector"), ModuleData::builder(OWNER))?;

--- a/piecrust/tests/vector.rs
+++ b/piecrust/tests/vector.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, DeployData, Error, VM};
+use piecrust::{module_bytecode, ModuleData, Error, VM};
 
 const OWNER: [u8; 32] = [0u8; 32];
 
@@ -15,7 +15,7 @@ pub fn vector_push_pop() -> Result<(), Error> {
     let mut session = vm.genesis_session();
 
     let id = session
-        .deploy(module_bytecode!("vector"), DeployData::builder(OWNER))?;
+        .deploy(module_bytecode!("vector"), ModuleData::builder(OWNER))?;
 
     const N: usize = 128;
 

--- a/piecrust/tests/vector.rs
+++ b/piecrust/tests/vector.rs
@@ -12,7 +12,7 @@ const OWNER: [u8; 32] = [0u8; 32];
 pub fn vector_push_pop() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.genesis_session(SessionData::new());
+    let mut session = vm.session(SessionData::builder())?;
 
     let id = session
         .deploy(module_bytecode!("vector"), ModuleData::builder(OWNER))?;

--- a/piecrust/tests/vector.rs
+++ b/piecrust/tests/vector.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{module_bytecode, ModuleData, Error, VM};
+use piecrust::{module_bytecode, Error, ModuleData, VM};
 
 const OWNER: [u8; 32] = [0u8; 32];
 


### PR DESCRIPTION
This PR implements issue #181. Implementation consists of the following parts:

1) (ModuleData) Renamed DeployData as ModuleData. Internal ModuleData has been renamed to ModuleDataEntry. Renamed session's method metadata to module_metadata.

2) (SessionData) Eliminated the set_meta API, enriched he session creation API (VM's methods session and genesis_session) as well as deployment API with the possibility of passing session data. Said session data, after session creation, is made accessible only as read-only.

3) (CallData) Is implemented in a separate branch to allow proper evaluation and discussion, otherwise the changes are too voluminous for easy evaluation. Branch name is `structure-improv-call-data-181`. Unlike points 1 and 2, I am not sure if changes for point 3 should be merged.
