### PR TITLE
Release `0.2.0`

### DIFF
--- a/piecrust-uplink/Cargo.toml
+++ b/piecrust-uplink/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.1.0"
+version = "0.2.0"
 
 edition = "2021"
 license = "MPL-2.0"

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,34 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2023-04-06
+
 ### Added
 
-- Derive `Debug` for `Session` and `VM`
-
-### Fixed
-
-- Implemented Display for ModuleId. [#178]
-- Removed SELF_ID export from contracts. [#167]
 - Added uplink::owner and uplink::self_id. [#158]
-- Added persistence fo module metadata. [#167]
+- Implemented Display for ModuleId. [#178]
+- Added persistence for module metadata. [#167]
 - Added `DeployData` and `DeployDataBuilder`. [#158]
-- Changed deploy API to accept `Into<DeployData>`. [#158]
 - Added contract constructor mechanism. [#93]
 - Added caching of module compilation outputs. [#162]
+- Derive `Debug` for `Session` and `VM`
+
+### Changed
+
+- Changed deploy API to accept `Into<DeployData>`. [#158]
 - Made modules compile at deploy time rather than on first query/transaction time. [#162]
+
+### Removed
+
 - Removed errant print statements.
+- Removed SELF_ID export from contracts. [#167]
 
 ## [0.1.0] - 2023-03-15
 
 - First `piecrust` release
 
 <!-- ISSUES -->
-[#93]: https://github.com/dusk-network/piecrust/issues/93
-[#158]: https://github.com/dusk-network/piecrust/issues/158
-[#162]: https://github.com/dusk-network/piecrust/issues/162
-[#167]: https://github.com/dusk-network/piecrust/issues/167
 [#178]: https://github.com/dusk-network/piecrust/issues/178
+[#167]: https://github.com/dusk-network/piecrust/issues/167
+[#162]: https://github.com/dusk-network/piecrust/issues/162
+[#158]: https://github.com/dusk-network/piecrust/issues/158
+[#93]: https://github.com/dusk-network/piecrust/issues/93
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/dusk-network/piecrust/releases/tag/v0.2.0
 [0.1.0]: https://github.com/dusk-network/piecrust/releases/tag/v0.1.0

--- a/piecrust/Cargo.toml
+++ b/piecrust/Cargo.toml
@@ -7,13 +7,13 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.1.0"
+version = "0.2.0"
 
 edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-piecrust-uplink = { version = "0.1.0-alpha", path = "../piecrust-uplink" }
+piecrust-uplink = { version = "0.2.0", path = "../piecrust-uplink" }
 
 wasmer = "3.1"
 wasmer-vm = "3.1"


### PR DESCRIPTION
## [0.2.0] - 2023-04-06

### Added

- Added uplink::owner and uplink::self_id. [#158]
- Implemented Display for ModuleId. [#178]
- Added persistence for module metadata. [#167]
- Added `DeployData` and `DeployDataBuilder`. [#158]
- Added contract constructor mechanism. [#93]
- Added caching of module compilation outputs. [#162]
- Derive `Debug` for `Session` and `VM`

### Changed

- Changed deploy API to accept `Into<DeployData>`. [#158]
- Made modules compile at deploy time rather than on first query/transaction time. [#162]

### Removed

- Removed errant print statements.
- Removed SELF_ID export from contracts. [#167]

[0.2.0]: https://github.com/dusk-network/piecrust/releases/tag/v0.2.0
