### PR TITLE
Support new alloc panic handling

### DIFF
--- a/piecrust-uplink/CHANGELOG.md
+++ b/piecrust-uplink/CHANGELOG.md
@@ -7,9 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added documentation for `piecrust-uplink::types`. [#139]
+
+### Removed
+
+- Removed deprecated `alloc_error_handler`. [#192]
+
 ## [0.1.0] - 2023-03-15
 
 - First `piecrust-uplink` release
 
+<!-- ISSUES -->
+[#192]: https://github.com/dusk-network/piecrust/issues/192
+[#139]: https://github.com/dusk-network/piecrust/pull/139
+
+<!-- VERSIONS -->
 [Unreleased]: https://github.com/dusk-network/piecrust/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/dusk-network/piecrust/releases/tag/v0.1.0

--- a/piecrust-uplink/src/handlers.rs
+++ b/piecrust-uplink/src/handlers.rs
@@ -37,9 +37,3 @@ extern "C" fn eh_personality() {}
 #[cfg(feature = "wee_alloc")]
 #[global_allocator]
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
-
-#[alloc_error_handler]
-fn foo(layout: core::alloc::Layout) -> ! {
-    crate::debug!("ALLOC ERROR {:?}", layout);
-    panic!("OOM");
-}

--- a/piecrust-uplink/src/lib.rs
+++ b/piecrust-uplink/src/lib.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 #![no_std]
 
 extern crate alloc;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2022-10-07"
+channel = "nightly-2023-04-24"
 targets = ["wasm32-unknown-unknown"]
 components = ["rust-src"]


### PR DESCRIPTION
This commit:
- Removes the old `alloc_panic_handler` feature flag.
- Removes the custom alloc panic handler.
- Ups the Rust nightly toolchain version.

Resolves #192 