### PR TITLE
Release `0.3.0`

### DIFF
--- a/piecrust-uplink/CHANGELOG.md
+++ b/piecrust-uplink/CHANGELOG.md
@@ -7,13 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2023-04-26
+
 ### Added
 
-- Added documentation for `piecrust-uplink::types`. [#139]
+- Add documentation for `piecrust-uplink::types`. [#139]
+
+### Changed
+
+- Rename `ModuleError` enum variants to be upper case.
 
 ### Removed
 
-- Removed deprecated `alloc_error_handler`. [#192]
+- Remove deprecated `alloc_error_handler`. [#192]
 
 ## [0.1.0] - 2023-03-15
 
@@ -24,5 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#139]: https://github.com/dusk-network/piecrust/pull/139
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/dusk-network/piecrust/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/dusk-network/piecrust/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/dusk-network/piecrust/releases/tag/v0.1.0

--- a/piecrust-uplink/Cargo.toml
+++ b/piecrust-uplink/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.2.0"
+version = "0.3.0"
 
 edition = "2021"
 license = "MPL-2.0"

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2023-04-26
+
+### Changed
+
+- Rename `DeployData` to `ModuleData`
+
+### Removed
+
+- Remove `VM::genesis_session` in favor of config parameters in `VM::session`
+
 ## [0.2.0] - 2023-04-06
 
 ### Added
@@ -43,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#93]: https://github.com/dusk-network/piecrust/issues/93
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/v0.2.0...HEAD
-[0.2.0]: https://github.com/dusk-network/piecrust/releases/tag/v0.2.0
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/dusk-network/piecrust/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/dusk-network/piecrust/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/dusk-network/piecrust/releases/tag/v0.1.0

--- a/piecrust/Cargo.toml
+++ b/piecrust/Cargo.toml
@@ -7,13 +7,13 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.2.0"
+version = "0.3.0"
 
 edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-piecrust-uplink = { version = "0.2.0", path = "../piecrust-uplink" }
+piecrust-uplink = { version = "0.3.0", path = "../piecrust-uplink" }
 
 wasmer = "=3.1"
 wasmer-vm = "=3.1"


### PR DESCRIPTION
## [0.3.0] - 2023-04-26

### Changed

- Rename `DeployData` to `ModuleData`

### Removed

- Remove `VM::genesis_session` in favor of config parameters in `VM::session`

## [0.3.0] - 2023-04-26

### Added

- Add documentation for `piecrust-uplink::types`. [#139]

### Changed

- Rename `ModuleError` enum variants to be upper case.

### Removed

- Remove deprecated `alloc_error_handler`. [#192]

[0.3.0]: https://github.com/dusk-network/piecrust/compare/v0.2.0...v0.3.0
