### PR TITLE
Remove `wee_alloc` and add `dlmalloc`

### DIFF
--- a/modules/box/Cargo.toml
+++ b/modules/box/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-piecrust-uplink = { path = "../../piecrust-uplink", default-features = false, features = ["wee_alloc"] }
+piecrust-uplink = { path = "../../piecrust-uplink", default-features = false, features = ["dlmalloc"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/modules/callcenter/Cargo.toml
+++ b/modules/callcenter/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-piecrust-uplink = { path = "../../piecrust-uplink", default-features = false, features = ["wee_alloc"] }
+piecrust-uplink = { path = "../../piecrust-uplink", default-features = false, features = ["dlmalloc"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/modules/constructor/Cargo.toml
+++ b/modules/constructor/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-piecrust-uplink = { path = "../../piecrust-uplink", default-features = false, features = ["wee_alloc"] }
+piecrust-uplink = { path = "../../piecrust-uplink", default-features = false, features = ["dlmalloc"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/modules/counter/Cargo.toml
+++ b/modules/counter/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-piecrust-uplink = { path = "../../piecrust-uplink", default-features = false, features = ["wee_alloc"] }
+piecrust-uplink = { path = "../../piecrust-uplink", default-features = false, features = ["dlmalloc"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/modules/crossover/Cargo.toml
+++ b/modules/crossover/Cargo.toml
@@ -11,4 +11,4 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-piecrust-uplink = { path = "../../piecrust-uplink", default-features = false, features = ["wee_alloc"] }
+piecrust-uplink = { path = "../../piecrust-uplink", default-features = false, features = ["dlmalloc"] }

--- a/modules/debugger/Cargo.toml
+++ b/modules/debugger/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-piecrust-uplink = { path = "../../piecrust-uplink", default-features = false, features = ["wee_alloc"] }
+piecrust-uplink = { path = "../../piecrust-uplink", default-features = false, features = ["dlmalloc"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/modules/eventer/Cargo.toml
+++ b/modules/eventer/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-piecrust-uplink = { path = "../../piecrust-uplink", default-features = false, features = ["wee_alloc"] }
+piecrust-uplink = { path = "../../piecrust-uplink", default-features = false, features = ["dlmalloc"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/modules/everest/Cargo.toml
+++ b/modules/everest/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-piecrust-uplink = { path = "../../piecrust-uplink", default-features = false, features = ["wee_alloc"] }
+piecrust-uplink = { path = "../../piecrust-uplink", default-features = false, features = ["dlmalloc"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/modules/fallible_counter/Cargo.toml
+++ b/modules/fallible_counter/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-piecrust-uplink = { path = "../../piecrust-uplink", default-features = false, features = ["wee_alloc"] }
+piecrust-uplink = { path = "../../piecrust-uplink", default-features = false, features = ["dlmalloc"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/modules/fibonacci/Cargo.toml
+++ b/modules/fibonacci/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-piecrust-uplink = { path = "../../piecrust-uplink", default-features = false, features = ["wee_alloc"] }
+piecrust-uplink = { path = "../../piecrust-uplink", default-features = false, features = ["dlmalloc"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/modules/host/Cargo.toml
+++ b/modules/host/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-piecrust-uplink = { path = "../../piecrust-uplink", default-features = false, features = ["wee_alloc"] }
+piecrust-uplink = { path = "../../piecrust-uplink", default-features = false, features = ["dlmalloc"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/modules/merkle/Cargo.toml
+++ b/modules/merkle/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-piecrust-uplink = { path = "../../piecrust-uplink", default-features = false, features = ["wee_alloc"] }
+piecrust-uplink = { path = "../../piecrust-uplink", default-features = false, features = ["dlmalloc"] }
 dusk-merkle = { version = "0.1", features = ["rkyv-impl"] }
 blake3 = { version = "1", default-features = false }
 

--- a/modules/metadata/Cargo.toml
+++ b/modules/metadata/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-piecrust-uplink = { path = "../../piecrust-uplink", default-features = false, features = ["wee_alloc"] }
+piecrust-uplink = { path = "../../piecrust-uplink", default-features = false, features = ["dlmalloc"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/modules/micro/Cargo.toml
+++ b/modules/micro/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-piecrust-uplink = { path = "../../piecrust-uplink", default-features = false, features = ["wee_alloc"] }
+piecrust-uplink = { path = "../../piecrust-uplink", default-features = false, features = ["dlmalloc"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/modules/spender/Cargo.toml
+++ b/modules/spender/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-piecrust-uplink = { path = "../../piecrust-uplink", default-features = false, features = ["wee_alloc"] }
+piecrust-uplink = { path = "../../piecrust-uplink", default-features = false, features = ["dlmalloc"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/modules/stack/Cargo.toml
+++ b/modules/stack/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-piecrust-uplink = { path = "../../piecrust-uplink", default-features = false, features = ["wee_alloc"] }
+piecrust-uplink = { path = "../../piecrust-uplink", default-features = false, features = ["dlmalloc"] }
 nstack = "0.16.0-rc"
 ranno = "0.1"
 

--- a/modules/vector/Cargo.toml
+++ b/modules/vector/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-piecrust-uplink = { path = "../../piecrust-uplink", default-features = false, features = ["wee_alloc"] }
+piecrust-uplink = { path = "../../piecrust-uplink", default-features = false, features = ["dlmalloc"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/piecrust-uplink/CHANGELOG.md
+++ b/piecrust-uplink/CHANGELOG.md
@@ -7,27 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Add crate-specific README. [#174]
+### Added
+
+- Add `dlmalloc` feature [#199]
+- Add crate-specific README [#174]
+
+### Removed
+
+- Remove `wee_alloc` feature [#199]
 
 ## [0.3.0] - 2023-04-26
 
 ### Added
 
-- Add documentation for `piecrust-uplink::types`. [#139]
+- Add documentation for `piecrust-uplink::types` [#139]
 
 ### Changed
 
-- Rename `ModuleError` enum variants to be upper case.
+- Rename `ModuleError` enum variants to be upper case
 
 ### Removed
 
-- Remove deprecated `alloc_error_handler`. [#192]
+- Remove deprecated `alloc_error_handler` [#192]
 
 ## [0.1.0] - 2023-03-15
 
 - First `piecrust-uplink` release
 
 <!-- ISSUES -->
+[#199]: https://github.com/dusk-network/piecrust/issues/199
 [#192]: https://github.com/dusk-network/piecrust/issues/192
 [#174]: https://github.com/dusk-network/piecrust/issues/174
 [#139]: https://github.com/dusk-network/piecrust/pull/139

--- a/piecrust-uplink/Cargo.toml
+++ b/piecrust-uplink/Cargo.toml
@@ -15,7 +15,7 @@ license = "MPL-2.0"
 [dependencies]
 rkyv = { version = "0.7", default-features = false, features = ["size_32", "alloc"] }
 bytecheck = { version = "0.6", default-features = false }
-wee_alloc = { version = "0.4", optional = true }
+dlmalloc = { version = "0.2", optional = true, features = ["global"] }
 
 [features]
 default = ["std"]

--- a/piecrust-uplink/src/handlers.rs
+++ b/piecrust-uplink/src/handlers.rs
@@ -34,6 +34,6 @@ fn panic(panic_info: &PanicInfo) -> ! {
 #[lang = "eh_personality"]
 extern "C" fn eh_personality() {}
 
-#[cfg(feature = "wee_alloc")]
+#[cfg(feature = "dlmalloc")]
 #[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
+static ALLOC: dlmalloc::GlobalDlmalloc = dlmalloc::GlobalDlmalloc;


### PR DESCRIPTION
`wee_alloc` is unmaintained, and as such shouldn't be used. `dlmalloc` is the default allocator for a `wasm32_unknown_unknown` target using the standard library and is a great candidate for use as the default global allocator in modules.

Resolves #199