### PR TITLE
Change `owner` type to `[u8; N]`

### DIFF
--- a/modules/metadata/src/lib.rs
+++ b/modules/metadata/src/lib.rs
@@ -20,7 +20,7 @@ static mut STATE: State<Metadata> = State::new(Metadata {});
 
 impl Metadata {
     /// Read the value of the module's owner
-    pub fn read_owner(&self) -> [u8; 32] {
+    pub fn read_owner(&self) -> [u8; 33] {
         uplink::owner()
     }
 

--- a/piecrust-uplink/CHANGELOG.md
+++ b/piecrust-uplink/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `dlmalloc` feature [#199]
 - Add crate-specific README [#174]
 
+### Changed
+
+- Change signature of `owner` to return `[u8; N]` instead of `[u8; 32]` [#201] 
+
 ### Removed
 
 - Remove `wee_alloc` feature [#199]
@@ -35,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - First `piecrust-uplink` release
 
 <!-- ISSUES -->
+[#201]: https://github.com/dusk-network/piecrust/issues/201
 [#199]: https://github.com/dusk-network/piecrust/issues/199
 [#192]: https://github.com/dusk-network/piecrust/issues/192
 [#174]: https://github.com/dusk-network/piecrust/issues/174

--- a/piecrust-uplink/src/state.rs
+++ b/piecrust-uplink/src/state.rs
@@ -268,10 +268,10 @@ pub fn height() -> u64 {
 }
 
 /// Return the current module's owner.
-pub fn owner() -> [u8; 32] {
+pub fn owner<const N: usize>() -> [u8; N] {
     let len = unsafe { ext::owner() } as usize;
     with_arg_buf(|buf| {
-        let ret = unsafe { archived_root::<[u8; 32]>(&buf[..len]) };
+        let ret = unsafe { archived_root::<[u8; N]>(&buf[..len]) };
         ret.deserialize(&mut Infallible).expect("Infallible")
     })
 }

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add crate-specific README. [#174]
 
+### Changed
+
+- Change `owner` parameter type in `ModuleData::builder` to be `[u8; N]` [#201] 
+
 ## [0.3.0] - 2023-04-26
 
 ### Changed
@@ -50,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - First `piecrust` release
 
 <!-- ISSUES -->
+[#201]: https://github.com/dusk-network/piecrust/issues/201
 [#181]: https://github.com/dusk-network/piecrust/issues/181
 [#178]: https://github.com/dusk-network/piecrust/issues/178
 [#174]: https://github.com/dusk-network/piecrust/issues/174

--- a/piecrust/src/module.rs
+++ b/piecrust/src/module.rs
@@ -14,20 +14,20 @@ use crate::error::Error;
 use crate::instance::Store;
 use piecrust_uplink::ModuleId;
 
-pub struct ModuleData<'a, A> {
+pub struct ModuleData<'a, A, const N: usize> {
     pub(crate) module_id: Option<ModuleId>,
     pub(crate) constructor_arg: Option<&'a A>,
-    pub(crate) owner: [u8; 32],
+    pub(crate) owner: [u8; N],
 }
 
 // `()` is done on purpose, since by default it should be that the constructor
 // takes no argument.
-impl<'a> ModuleData<'a, ()> {
+impl<'a, const N: usize> ModuleData<'a, (), N> {
     /// Build a deploy data structure.
     ///
     /// This function returns a builder that can be used to set optional fields
     /// in module deployment.
-    pub fn builder(owner: [u8; 32]) -> ModuleDataBuilder<'a, ()> {
+    pub fn builder(owner: [u8; N]) -> ModuleDataBuilder<'a, (), N> {
         ModuleDataBuilder {
             module_id: None,
             constructor_arg: None,
@@ -36,19 +36,21 @@ impl<'a> ModuleData<'a, ()> {
     }
 }
 
-impl<'a, A> From<ModuleDataBuilder<'a, A>> for ModuleData<'a, A> {
-    fn from(builder: ModuleDataBuilder<'a, A>) -> Self {
+impl<'a, A, const N: usize> From<ModuleDataBuilder<'a, A, N>>
+    for ModuleData<'a, A, N>
+{
+    fn from(builder: ModuleDataBuilder<'a, A, N>) -> Self {
         builder.build()
     }
 }
 
-pub struct ModuleDataBuilder<'a, A> {
+pub struct ModuleDataBuilder<'a, A, const N: usize> {
     module_id: Option<ModuleId>,
-    owner: [u8; 32],
+    owner: [u8; N],
     constructor_arg: Option<&'a A>,
 }
 
-impl<'a, A> ModuleDataBuilder<'a, A> {
+impl<'a, A, const N: usize> ModuleDataBuilder<'a, A, N> {
     /// Set the deployment module ID.
     pub fn module_id(mut self, id: ModuleId) -> Self {
         self.module_id = Some(id);
@@ -56,7 +58,7 @@ impl<'a, A> ModuleDataBuilder<'a, A> {
     }
 
     /// Set the constructor argument for deployment.
-    pub fn constructor_arg<B>(self, arg: &B) -> ModuleDataBuilder<B> {
+    pub fn constructor_arg<B>(self, arg: &B) -> ModuleDataBuilder<B, N> {
         ModuleDataBuilder {
             module_id: self.module_id,
             owner: self.owner,
@@ -64,7 +66,7 @@ impl<'a, A> ModuleDataBuilder<'a, A> {
         }
     }
 
-    pub fn build(self) -> ModuleData<'a, A> {
+    pub fn build(self) -> ModuleData<'a, A, N> {
         ModuleData {
             module_id: self.module_id,
             constructor_arg: self.constructor_arg,
@@ -77,7 +79,7 @@ impl<'a, A> ModuleDataBuilder<'a, A> {
 #[archive_attr(derive(CheckBytes))]
 pub struct ModuleMetadata {
     pub module_id: ModuleId,
-    pub owner: [u8; 32],
+    pub owner: Vec<u8>,
 }
 
 #[derive(Clone)]

--- a/piecrust/tests/metadata.rs
+++ b/piecrust/tests/metadata.rs
@@ -9,7 +9,7 @@ use piecrust_uplink::ModuleId;
 
 #[test]
 fn metadata() -> Result<(), Error> {
-    const EXPECTED_OWNER: [u8; 32] = [3u8; 32];
+    const EXPECTED_OWNER: [u8; 33] = [3u8; 33];
 
     let vm = VM::ephemeral()?;
 
@@ -21,7 +21,7 @@ fn metadata() -> Result<(), Error> {
     )?;
 
     // owner should be available after deployment
-    let owner = session.query::<(), [u8; 32]>(id, "read_owner", &())?;
+    let owner = session.query::<(), [u8; 33]>(id, "read_owner", &())?;
     let self_id = session.query::<(), ModuleId>(id, "read_id", &())?;
     assert_eq!(owner, EXPECTED_OWNER);
     assert_eq!(self_id, id);
@@ -29,7 +29,7 @@ fn metadata() -> Result<(), Error> {
     // owner should live across session boundaries
     let commit_id = session.commit()?;
     let mut session = vm.session(SessionData::builder().base(commit_id))?;
-    let owner = session.query::<(), [u8; 32]>(id, "read_owner", &())?;
+    let owner = session.query::<(), [u8; 33]>(id, "read_owner", &())?;
     let self_id = session.query::<(), ModuleId>(id, "read_id", &())?;
     assert_eq!(owner, EXPECTED_OWNER);
     assert_eq!(self_id, id);


### PR DESCRIPTION
This allows the consumer of the `piecrust` crate to define how large
they want the owner to be when offered to a module. Internally, we
handle the owner as a `Vec<u8>`, however it gets passed to a module as
a `[u8; N]`.

Resolves: #201
