### PR TITLE
Release `0.4.0`

### DIFF
--- a/piecrust-uplink/CHANGELOG.md
+++ b/piecrust-uplink/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2023-05-17
+
 ### Added
 
 - Add `call` and associated functions and structs [#136]
@@ -53,7 +55,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#136]: https://github.com/dusk-network/piecrust/issues/136
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/dusk-network/piecrust/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/dusk-network/piecrust/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/dusk-network/piecrust/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/dusk-network/piecrust/releases/tag/v0.1.0

--- a/piecrust-uplink/Cargo.toml
+++ b/piecrust-uplink/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.3.0"
+version = "0.4.0"
 
 edition = "2021"
 license = "MPL-2.0"

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2023-05-17
+
 ### Added
 
 - Add `RawCall` re-export [#136]
@@ -81,7 +83,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#93]: https://github.com/dusk-network/piecrust/issues/93
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/dusk-network/piecrust/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/dusk-network/piecrust/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/dusk-network/piecrust/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/dusk-network/piecrust/releases/tag/v0.1.0

--- a/piecrust/Cargo.toml
+++ b/piecrust/Cargo.toml
@@ -7,13 +7,13 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.3.0"
+version = "0.4.0"
 
 edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-piecrust-uplink = { version = "0.3.0", path = "../piecrust-uplink" }
+piecrust-uplink = { version = "0.4.0", path = "../piecrust-uplink" }
 
 wasmer = "=3.1"
 wasmer-vm = "=3.1"


### PR DESCRIPTION
## [piecrust-uplink 0.4.0] - 2023-05-17

### Added

- Add `call` and associated functions and structs [#136]
- Add `dlmalloc` feature [#199]
- Add crate-specific README [#174]

### Changed

- Change `module` named functions and items to `contract` [#207]
- Change signature of `owner` to return `[u8; N]` instead of `[u8; 32]` [#201] 

### Removed

- Remove `State` struct [#209]
- Remove `query` and `transact` and associated functions and structs [#136]
- Remove `wee_alloc` feature [#199]

## [piecrust 0.4.0] - 2023-05-17

### Added

- Add `RawCall` re-export [#136]
- Add `Session::call` [#136]
- Add crate-specific README. [#174]

### Changed

- Change `owner` parameter type in `ModuleData::builder` to be `[u8; N]` [#201] 

### Fixed

- Fix SIGSEGV caused by moving sessions with instantiate modules [#202]

### Removed

- Remove `RawQuery/Transact` re-rexports [#136]
- Remove `Session::query/transact` [#136]
- Remove `query/transact` imports [#136]


[piecrust-uplink 0.4.0]: https://github.com/dusk-network/piecrust/compare/v0.3.0...v0.4.0
[piecrust 0.4.0]: https://github.com/dusk-network/piecrust/compare/v0.3.0...v0.4.0