### PR TITLE
piecrust: add `MAP_NORESERVE` flag to mmap

### DIFF
--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add `MAP_NORESERVE` flag to `mmap` syscall [#213]
+
 ## [0.4.0] - 2023-05-17
 
 ### Added
@@ -69,6 +72,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - First `piecrust` release
 
 <!-- ISSUES -->
+[#213]: https://github.com/dusk-network/piecrust/issues/213
 [#207]: https://github.com/dusk-network/piecrust/issues/207
 [#202]: https://github.com/dusk-network/piecrust/issues/202
 [#201]: https://github.com/dusk-network/piecrust/issues/201

--- a/piecrust/src/store/mmap.rs
+++ b/piecrust/src/store/mmap.rs
@@ -14,7 +14,8 @@ use std::ptr::NonNull;
 use std::{io, slice};
 
 use libc::{
-    MAP_ANONYMOUS, MAP_FAILED, MAP_FIXED, MAP_PRIVATE, PROT_READ, PROT_WRITE,
+    MAP_ANONYMOUS, MAP_FAILED, MAP_FIXED, MAP_NORESERVE, MAP_PRIVATE,
+    PROT_READ, PROT_WRITE,
 };
 use tempfile::tempfile;
 use wasmer_types::{MemoryError, MemoryStyle, MemoryType, Pages};
@@ -127,7 +128,7 @@ impl Mmap {
             len,
             len,
             PROT_READ | PROT_WRITE,
-            MAP_PRIVATE | MAP_ANONYMOUS,
+            MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE,
             -1,
         )?;
         inner.as_bytes_mut().copy_from_slice(bytes);
@@ -189,7 +190,7 @@ impl MmapMut {
             file_len,
             MMAP_SIZE,
             PROT_READ | PROT_WRITE,
-            MAP_PRIVATE,
+            MAP_PRIVATE | MAP_NORESERVE,
             fd,
         )?))
     }
@@ -206,7 +207,7 @@ impl MmapMut {
             file_len,
             MMAP_SIZE,
             PROT_READ | PROT_WRITE,
-            MAP_PRIVATE,
+            MAP_PRIVATE | MAP_NORESERVE,
             fd,
         )?))
     }
@@ -225,7 +226,7 @@ impl MmapMut {
             file_len,
             MMAP_SIZE,
             PROT_READ | PROT_WRITE,
-            MAP_PRIVATE | MAP_FIXED,
+            MAP_PRIVATE | MAP_FIXED | MAP_NORESERVE,
             fd,
         )?;
 


### PR DESCRIPTION
MAP_NORESERVE flag has been tested on devnet cluster (using https://github.com/dusk-network/rusk/commit/6dc5788cc6589a22ac8f372a90f3203ef235798d)

Resolves #213