### PR TITLE
Handle contract-passed points_limit

### DIFF
--- a/contracts/spender/src/lib.rs
+++ b/contracts/spender/src/lib.rs
@@ -50,6 +50,11 @@ impl Spender {
             false => (limit, spent_before, 0, 0, 0),
         }
     }
+
+    /// Spend all points that are given to the contract.
+    pub fn spend() {
+        panic!("I like spending");
+    }
 }
 
 /// Expose `Spender::get_limit_and_spent()` to the host

--- a/piecrust-uplink/CHANGELOG.md
+++ b/piecrust-uplink/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `call_with_limit` and `call_raw_with_limit` [#216]
+
+### Changed
+
+- Include `points_limit` in the `c` external [#216]
+
 ## [0.4.0] - 2023-05-17
 
 ### Added
@@ -45,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - First `piecrust-uplink` release
 
 <!-- ISSUES -->
+[#216]: https://github.com/dusk-network/piecrust/issues/216
 [#209]: https://github.com/dusk-network/piecrust/issues/209
 [#207]: https://github.com/dusk-network/piecrust/issues/207
 [#201]: https://github.com/dusk-network/piecrust/issues/201

--- a/piecrust-uplink/src/lib.rs
+++ b/piecrust-uplink/src/lib.rs
@@ -15,8 +15,8 @@ pub use snap::snap;
 
 mod state;
 pub use state::{
-    call, call_raw, caller, emit, height, host_query, limit, meta_data, owner,
-    self_id, spent, ContractError,
+    call, call_raw, call_raw_with_limit, call_with_limit, caller, emit, height,
+    host_query, limit, meta_data, owner, self_id, spent, ContractError,
 };
 
 mod helpers;

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -8,7 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
 - Add `MAP_NORESERVE` flag to `mmap` syscall [#213]
+
+### Changed
+
+- Include `points_limit` in `c` import [#216]
 
 ## [0.4.0] - 2023-05-17
 
@@ -72,6 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - First `piecrust` release
 
 <!-- ISSUES -->
+[#216]: https://github.com/dusk-network/piecrust/issues/216
 [#213]: https://github.com/dusk-network/piecrust/issues/213
 [#207]: https://github.com/dusk-network/piecrust/issues/207
 [#202]: https://github.com/dusk-network/piecrust/issues/202

--- a/piecrust/src/imports.rs
+++ b/piecrust/src/imports.rs
@@ -55,6 +55,7 @@ fn c(
     name_ofs: i32,
     name_len: u32,
     arg_len: u32,
+    points_limit: u64,
 ) -> Result<i32, Error> {
     let env = fenv.data_mut();
 
@@ -64,7 +65,12 @@ fn c(
     let caller_remaining = instance
         .get_remaining_points()
         .expect("there should be points remaining");
-    let callee_limit = caller_remaining * POINT_PASS_PCT / 100;
+
+    let callee_limit = if points_limit > 0 && points_limit < caller_remaining {
+        points_limit
+    } else {
+        caller_remaining * POINT_PASS_PCT / 100
+    };
 
     // If an error is returned then we are in a re-execution, and should signal
     // the contract without executing the call.


### PR DESCRIPTION
Allows for the point limit to be passed by a contract when performing a call.

Resolves #216