### PR TITLE
Release `0.5.0`

### DIFF
--- a/piecrust-uplink/CHANGELOG.md
+++ b/piecrust-uplink/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2023-06-07
+
 ### Added
 
 - Add `call_with_limit` and `call_raw_with_limit` [#216]
@@ -64,7 +66,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#136]: https://github.com/dusk-network/piecrust/issues/136
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/dusk-network/piecrust/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/dusk-network/piecrust/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/dusk-network/piecrust/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/dusk-network/piecrust/compare/v0.1.0...v0.2.0

--- a/piecrust-uplink/Cargo.toml
+++ b/piecrust-uplink/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.4.0"
+version = "0.5.0"
 
 edition = "2021"
 license = "MPL-2.0"

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2023-06-07
+
 ### Added
 
 - Add `Session::call_raw` allowing for deferred (de)serialization [#218]
@@ -95,7 +97,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#93]: https://github.com/dusk-network/piecrust/issues/93
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/dusk-network/piecrust/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/dusk-network/piecrust/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/dusk-network/piecrust/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/dusk-network/piecrust/compare/v0.1.0...v0.2.0

--- a/piecrust/Cargo.toml
+++ b/piecrust/Cargo.toml
@@ -7,13 +7,13 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.4.0"
+version = "0.5.0"
 
 edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-piecrust-uplink = { version = "0.4.0", path = "../piecrust-uplink" }
+piecrust-uplink = { version = "0.5.0", path = "../piecrust-uplink" }
 
 wasmer = "=3.1"
 wasmer-vm = "=3.1"


### PR DESCRIPTION
## [piecrust 0.5.0] - 2023-06-07

### Added

- Add `Session::call_raw` allowing for deferred (de)serialization [#218]
- Add `MAP_NORESERVE` flag to `mmap` syscall [#213]

### Changed

- Include `points_limit` in `c` import [#216]

## [piecrust-uplink 0.5.0] - 2023-06-07

### Added

- Add `call_with_limit` and `call_raw_with_limit` [#216]

### Changed

- Include `points_limit` in the `c` external [#216]

[piecrust 0.5.0]: https://github.com/dusk-network/piecrust/compare/v0.4.0...v0.5.0
[piecrust-uplink 0.5.0]: https://github.com/dusk-network/piecrust/compare/v0.4.0...v0.5.0