### PR TITLE
Release 0.1.1

### DIFF
--- a/piecrust-uplink/CHANGELOG.md
+++ b/piecrust-uplink/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2023-06-08
+
 ## [0.1.0] - 2023-03-15
 
 - First `piecrust-uplink` release
 
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/v0.1.1...0.1.x
+[0.1.1]: https://github.com/dusk-network/piecrust/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/dusk-network/piecrust/releases/tag/v0.1.0

--- a/piecrust-uplink/Cargo.toml
+++ b/piecrust-uplink/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.1.0"
+version = "0.1.1"
 
 edition = "2021"
 license = "MPL-2.0"

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,9 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2023-06-08
+
+### Added
+- Add `MAP_NORESERVE` flag to `mmap` syscall [#213]
+
 ## [0.1.0] - 2023-03-15
 
 - First `piecrust` release
 
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/v0.1.0...HEAD
+<!-- ISSUES -->
+[#213]: https://github.com/dusk-network/piecrust/issues/213
+
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/v0.1.1...0.1.x
+[0.1.1]: https://github.com/dusk-network/piecrust/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/dusk-network/piecrust/releases/tag/v0.1.0

--- a/piecrust/Cargo.toml
+++ b/piecrust/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.1.0"
+version = "0.1.1"
 
 edition = "2021"
 license = "MPL-2.0"


### PR DESCRIPTION
## [0.1.1] - 2023-06-08

### Added
- Add `MAP_NORESERVE` flag to `mmap` syscall [#213]

[0.1.1]: https://github.com/dusk-network/piecrust/compare/v0.1.0...v0.1.1
