### PR TITLE
Add example contract written in C

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ contracts: ## Build example contracts
 	  -Z build-std=core,alloc,panic_abort \
 	  -Z build-std-features=panic_immediate_abort \
 	  --target wasm32-unknown-unknown
+	@contracts/c-example/build.sh
 	@mkdir -p target/stripped
 	@find target/wasm32-unknown-unknown/release -maxdepth 1 -name "*.wasm" \
 	    | xargs -I % basename % \

--- a/contracts/c-example/build.sh
+++ b/contracts/c-example/build.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+
+BASEDIR=$(dirname "$0")
+
+clang -nostdlib -Os \
+   --target=wasm32 \
+   -Wl,--allow-undefined \
+   -Wl,--no-entry \
+   -Wl,--export=A \
+   -Wl,--export=increment_and_read \
+   "$BASEDIR/contract.c" \
+   -o "$BASEDIR/../../target/wasm32-unknown-unknown/release/c-example.wasm"

--- a/contracts/c-example/contract.c
+++ b/contracts/c-example/contract.c
@@ -1,0 +1,80 @@
+#include <stdint.h>
+
+#define ARGBUF_LEN 65536
+
+// Define the argument buffer used to communicate between contract and host
+uint8_t A[ARGBUF_LEN];
+
+// ==== Host functions ====
+//
+// These functions are provided by the host. See `piecrust-uplink` for a full
+// list. Here we only declare the ones we will need.
+
+extern uint32_t c(
+    uint8_t *contract_id,
+    uint8_t *fn_name,
+    uint32_t fn_name_len,
+    uint32_t fn_arg_len,
+    uint64_t points_limit
+);
+
+inline static void memcpy(void *target, void *source, uint32_t len) {
+    uint8_t *t = (uint8_t*) target;
+    uint8_t *s = (uint8_t*) source;
+
+    for (uint32_t i = 0; i < len; ++i) {
+        t[i] = s[i];
+    }
+}
+
+// ==== Helper functions ====
+//
+// These will help us write the exported functions underneath
+
+// Reads a contract ID from the argument buffer
+inline static void read_contract_id(uint8_t id[32]) {
+    memcpy(id, A, 32);
+}
+
+// Calls the counter contract to increment the counter
+inline static void increment_counter(uint8_t contract_id[32]) {
+    uint32_t fn_name_len = 9;
+    uint8_t fn_name[9] = "increment";
+    c(contract_id, fn_name, fn_name_len, 0, 0);
+}
+
+// Reads a 64-bit from the argument buffer
+inline static void read_integer(int64_t *i) {
+    memcpy(i, A, 8);
+}
+
+// Writes a 64-bit integer to the argument buffer
+inline static void write_integer(int64_t i) {
+    memcpy(A, &i, 8);
+}
+
+// Calls the counter contract to read the counter
+inline static int64_t read_counter(uint8_t contract_id[32]) {
+    uint32_t fn_name_len = 10;
+    uint8_t fn_name[10] = "read_value";
+
+    c(contract_id, fn_name, fn_name_len, 0, 0);
+
+    int64_t i;
+    read_integer(&i);
+    return i;
+}
+
+// ==== Exported functions ====
+
+// Increments and reads the counter contract. The function expects the counter
+// contract ID to be written to the argument buffer before being called.
+int32_t increment_and_read(int32_t _arg_len) {
+    uint8_t counter_id[32];
+    read_contract_id(counter_id);
+    increment_counter(counter_id);
+
+    int64_t i = read_counter(counter_id);
+    write_integer(i);
+    return 8;
+}

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove `Into<PathBuf>` bound in `VM::new`
 - Rename `host_debug` export to `hdebug` [#222]
 
+### Removed
+
+- Remove `__heap_base` requirement from contracts
+
 ## [0.5.0] - 2023-06-07
 
 ### Added

--- a/piecrust/src/instance.rs
+++ b/piecrust/src/instance.rs
@@ -33,8 +33,6 @@ use crate::Error;
 pub struct WrappedInstance {
     instance: wasmer::Instance,
     arg_buf_ofs: usize,
-    #[allow(unused)]
-    heap_base: usize,
     store: wasmer::Store,
 }
 
@@ -159,17 +157,10 @@ impl WrappedInstance {
                 _ => todo!("Missing `A` Argbuf export"),
             };
 
-        let heap_base =
-            match instance.exports.get_global("__heap_base")?.get(&mut store) {
-                wasmer::Value::I32(i) => i as usize,
-                _ => todo!("Missing heap base"),
-            };
-
         let wrapped = WrappedInstance {
             store,
             instance,
             arg_buf_ofs,
-            heap_base,
         };
 
         Ok(wrapped)
@@ -295,13 +286,10 @@ impl WrappedInstance {
 
                         let buf_start = self.arg_buf_ofs;
                         let buf_end = buf_start + uplink::ARGBUF_LEN;
-                        let heap_base = self.heap_base;
 
                         if ofs + i >= buf_start && ofs + i < buf_end {
-                            print!("{}", format!("{byte:02x}").red());
+                            print!("{}", format!("{byte:02x}").green());
                             print!(" ");
-                        } else if ofs + i >= heap_base {
-                            print!("{}", format!("{byte:02x} ").green());
                         } else {
                             print!("{byte:02x} ")
                         }

--- a/piecrust/tests/counter.rs
+++ b/piecrust/tests/counter.rs
@@ -39,3 +39,28 @@ fn counter_read_write_simple() -> Result<(), Error> {
 
     Ok(())
 }
+
+#[test]
+fn call_through_c() -> Result<(), Error> {
+    let vm = VM::ephemeral()?;
+
+    let mut session = vm.session(SessionData::builder())?;
+
+    let counter_id = session
+        .deploy(contract_bytecode!("counter"), ContractData::builder(OWNER))?;
+    let c_example_id = session.deploy(
+        contract_bytecode!("c-example"),
+        ContractData::builder(OWNER),
+    )?;
+
+    assert_eq!(
+        session.call::<_, i64>(
+            c_example_id,
+            "increment_and_read",
+            &counter_id
+        )?,
+        0xfd
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
An experiment in using different languages to target the `piecrust` VM. It resulted in a contract, written in C, that calls the counter contract to increment the counter, and then calls it again to read the counter value. It then proceeds to return the value back to the caller.

As a consequence of the experiment, it was discovered that we don't really require the `__heap_base` export and as such it is removed in this PR.