### PR TITLE
Release `0.6.0`

### DIFF
--- a/piecrust-uplink/CHANGELOG.md
+++ b/piecrust-uplink/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2023-06-28
+
 ### Added
 
 - Add `Event` struct according to spec
@@ -87,7 +89,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#136]: https://github.com/dusk-network/piecrust/issues/136
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/dusk-network/piecrust/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/dusk-network/piecrust/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/dusk-network/piecrust/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/dusk-network/piecrust/compare/v0.2.0...v0.3.0

--- a/piecrust-uplink/Cargo.toml
+++ b/piecrust-uplink/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.5.0"
+version = "0.6.0"
 
 edition = "2021"
 license = "MPL-2.0"

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2023-06-28
+
 ### Added
 
 - Add `debug` feature, gating debugging capabilities [#222]
@@ -119,7 +121,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#93]: https://github.com/dusk-network/piecrust/issues/93
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/dusk-network/piecrust/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/dusk-network/piecrust/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/dusk-network/piecrust/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/dusk-network/piecrust/compare/v0.2.0...v0.3.0

--- a/piecrust/Cargo.toml
+++ b/piecrust/Cargo.toml
@@ -7,13 +7,13 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.5.0"
+version = "0.6.0"
 
 edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-piecrust-uplink = { version = "0.5.0", path = "../piecrust-uplink" }
+piecrust-uplink = { version = "0.6.0", path = "../piecrust-uplink" }
 
 wasmer = "=3.1"
 wasmer-vm = "=3.1"


### PR DESCRIPTION
## [piecrust-uplink 0.6.0] - 2023-06-28

### Added

- Add `Event` struct according to spec
- Impl `fmt::Display` for `ContractError`
- Emit debug line on panic handler [#222]
- Add `debug` feature [#222]

### Changed

- Change `emit` extern to include topic
- Rename `MODULE_ID_BYTES` to `CONTRACT_ID_BYTES`
- Expose `extern`s only on feature `abi` [#222]
- Rename `std` feature to `abi` [#222]
- Rename `host_debug` to `hdebug` and use arg buffer [#222]

### Removed

- Remove unused `height` extern [#222]
- Remove unused `snap` extern [#222]


## [piecrust 0.6.0] - 2023-06-28

### Added

- Add `debug` feature, gating debugging capabilities [#222]

### Changed

- Change event handling to emit `piecrust-uplink::Event`
- Change `emit` export to include topic
- Remove `Into<PathBuf>` bound in `VM::new`
- Rename `host_debug` export to `hdebug` [#222]

### Fixed

- Fix memleak due to last contract instance not being reclaimed
  in session.

### Removed

- Remove `Event` struct
- Remove `__heap_base` requirement from contracts

[piecrust 0.6.0]: https://github.com/dusk-network/piecrust/compare/v0.5.0...v0.6.0
[piecrust-uplink 0.6.0]: https://github.com/dusk-network/piecrust/compare/v0.5.0...v0.6.0