### PR TITLE
Re-export the contents of `piecrust-uplink` in `piecrust`

### DIFF
--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Re-export the entirety of `piecrust-uplink` [#234]
 
+### Change
+
+- Allow for `piecrust-uplink` version variability [#234]
+
 ## [0.6.0] - 2023-06-28
 
 ### Added

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Re-export the entirety of `piecrust-uplink` [#234]
+
 ## [0.6.0] - 2023-06-28
 
 ### Added
@@ -101,6 +105,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.0] - 2023-03-15
 
 - First `piecrust` release
+
+<!-- PULLS -->
+[#234]: https://github.com/dusk-network/piecrust/pull/234
 
 <!-- ISSUES -->
 [#222]: https://github.com/dusk-network/piecrust/issues/222

--- a/piecrust/Cargo.toml
+++ b/piecrust/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-piecrust-uplink = { version = "0.6.0", path = "../piecrust-uplink" }
+piecrust-uplink = { version = "0.6", path = "../piecrust-uplink" }
 
 wasmer = "=3.1"
 wasmer-vm = "=3.1"

--- a/piecrust/src/lib.rs
+++ b/piecrust/src/lib.rs
@@ -121,6 +121,6 @@ pub use error::Error;
 pub use session::{Session, SessionData};
 pub use vm::{HostQuery, VM};
 
-// re-exports
-
-pub use piecrust_uplink::{ContractId, RawCall};
+// re-export the contents of the `piecrust-uplink` crate wholesale, ensuring
+// this is the only crate we need to define and use a VM.
+pub use piecrust_uplink::*;


### PR DESCRIPTION
This ensures that `piecrust` is the only crate required for defining and interacting with a VM, while also allowing for any compatible version of `piecrust-uplink` to be used. 