### PR TITLE
piecrust: bump version to `0.6.1`

### DIFF
--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2023-06-28
+
 ### Added
 
 - Re-export the entirety of `piecrust-uplink` [#234]
@@ -132,7 +134,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#93]: https://github.com/dusk-network/piecrust/issues/93
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/piecrust-0.6.1...HEAD
+[0.6.1]: https://github.com/dusk-network/piecrust/compare/v0.6.0...piecrust-0.6.1
 [0.6.0]: https://github.com/dusk-network/piecrust/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/dusk-network/piecrust/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/dusk-network/piecrust/compare/v0.3.0...v0.4.0

--- a/piecrust/Cargo.toml
+++ b/piecrust/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.6.0"
+version = "0.6.1"
 
 edition = "2021"
 license = "MPL-2.0"


### PR DESCRIPTION
## [0.6.1] - 2023-06-28

### Added

- Re-export the entirety of `piecrust-uplink` [#234]

[0.6.1]: https://github.com/dusk-network/piecrust/compare/v0.6.0...piecrust-0.6.1
