### PR TITLE
Expand error handling

### DIFF
--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Handle possible errors in imports
 - Handle error on deserializing contract metadata
 - Change signature of `Session::deploy` to take `points_limit`
 - Change signature of `Session::call` to take `points_limit`

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `Error::MissingHostData` variant
+- Add `Error::MissingHostQuery` variant
 - Add `Error::Utf8` variant
 - Add `CallReceipt` struct
 

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `Error::Utf8` variant
 - Add `CallReceipt` struct
 
 ### Changed

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `Error::Infallible` variant
 - Add `Error::MissingHostData` variant
 - Add `Error::MissingHostQuery` variant
 - Add `Error::Utf8` variant

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Handle error on deserializing contract metadata
 - Change signature of `Session::deploy` to take `points_limit`
 - Change signature of `Session::call` to take `points_limit`
 - Change signature of `Session::call_raw` to take `points_limit`

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Change signature of `SessionDataBuilder::insert` to return an error on serialization
 - Handle possible errors in imports
 - Handle error on deserializing contract metadata
 - Change signature of `Session::deploy` to take `points_limit`

--- a/piecrust/src/error.rs
+++ b/piecrust/src/error.rs
@@ -42,6 +42,10 @@ pub enum Error {
     InstantiationError(Arc<wasmer::InstantiationError>),
     #[error(transparent)]
     MemorySetupError(Arc<std::io::Error>),
+    #[error("Missing host data: {0}")]
+    MissingHostData(String),
+    #[error("Missing host query: {0}")]
+    MissingHostQuery(String),
     #[error("OutOfPoints")]
     OutOfPoints,
     #[error(transparent)]

--- a/piecrust/src/error.rs
+++ b/piecrust/src/error.rs
@@ -22,22 +22,10 @@ pub type Compo = CompositeSerializerError<
 /// The error type returned by the piecrust VM.
 #[derive(Error, Debug, Clone)]
 pub enum Error {
-    #[error(transparent)]
-    InstantiationError(Arc<wasmer::InstantiationError>),
+    #[error("Commit error: {0}")]
+    CommitError(Cow<'static, str>),
     #[error(transparent)]
     CompileError(Arc<wasmer::CompileError>),
-    #[error(transparent)]
-    ExportError(Arc<wasmer::ExportError>),
-    #[error(transparent)]
-    RuntimeError(wasmer::RuntimeError),
-    #[error(transparent)]
-    SerializeError(Arc<wasmer::SerializeError>),
-    #[error(transparent)]
-    DeserializeError(Arc<wasmer::DeserializeError>),
-    #[error(transparent)]
-    ParsingError(wasmer::wasmparser::BinaryReaderError),
-    #[error("WASMER TRAP")]
-    Trap(Arc<wasmer_vm::Trap>),
     #[error(transparent)]
     CompositeSerializerError(Arc<Compo>),
     #[error(transparent)]
@@ -45,21 +33,33 @@ pub enum Error {
     #[error("Contract does not exist: {0}")]
     ContractDoesNotExist(ContractId),
     #[error(transparent)]
-    PersistenceError(Arc<std::io::Error>),
-    #[error("Commit error: {0}")]
-    CommitError(Cow<'static, str>),
+    DeserializeError(Arc<wasmer::DeserializeError>),
     #[error(transparent)]
-    RestoreError(Arc<std::io::Error>),
-    #[error("Session error: {0}")]
-    SessionError(Cow<'static, str>),
-    #[error(transparent)]
-    MemorySetupError(Arc<std::io::Error>),
-    #[error("ValidationError")]
-    ValidationError,
-    #[error("OutOfPoints")]
-    OutOfPoints,
+    ExportError(Arc<wasmer::ExportError>),
     #[error("InitalizationError: {0}")]
     InitalizationError(Cow<'static, str>),
+    #[error(transparent)]
+    InstantiationError(Arc<wasmer::InstantiationError>),
+    #[error(transparent)]
+    MemorySetupError(Arc<std::io::Error>),
+    #[error("OutOfPoints")]
+    OutOfPoints,
+    #[error(transparent)]
+    ParsingError(wasmer::wasmparser::BinaryReaderError),
+    #[error(transparent)]
+    PersistenceError(Arc<std::io::Error>),
+    #[error(transparent)]
+    RestoreError(Arc<std::io::Error>),
+    #[error(transparent)]
+    RuntimeError(wasmer::RuntimeError),
+    #[error(transparent)]
+    SerializeError(Arc<wasmer::SerializeError>),
+    #[error("Session error: {0}")]
+    SessionError(Cow<'static, str>),
+    #[error("WASMER TRAP")]
+    Trap(Arc<wasmer_vm::Trap>),
+    #[error("ValidationError")]
+    ValidationError,
 }
 
 impl From<wasmer::InstantiationError> for Error {

--- a/piecrust/src/error.rs
+++ b/piecrust/src/error.rs
@@ -5,6 +5,7 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use std::borrow::Cow;
+use std::convert::Infallible;
 use std::sync::Arc;
 use thiserror::Error;
 
@@ -36,6 +37,8 @@ pub enum Error {
     DeserializeError(Arc<wasmer::DeserializeError>),
     #[error(transparent)]
     ExportError(Arc<wasmer::ExportError>),
+    #[error(transparent)]
+    Infallible(std::convert::Infallible),
     #[error("InitalizationError: {0}")]
     InitalizationError(Cow<'static, str>),
     #[error(transparent)]
@@ -66,6 +69,12 @@ pub enum Error {
     Utf8(std::str::Utf8Error),
     #[error("ValidationError")]
     ValidationError,
+}
+
+impl From<std::convert::Infallible> for Error {
+    fn from(err: Infallible) -> Self {
+        Self::Infallible(err)
+    }
 }
 
 impl From<std::str::Utf8Error> for Error {

--- a/piecrust/src/error.rs
+++ b/piecrust/src/error.rs
@@ -58,8 +58,16 @@ pub enum Error {
     SessionError(Cow<'static, str>),
     #[error("WASMER TRAP")]
     Trap(Arc<wasmer_vm::Trap>),
+    #[error(transparent)]
+    Utf8(std::str::Utf8Error),
     #[error("ValidationError")]
     ValidationError,
+}
+
+impl From<std::str::Utf8Error> for Error {
+    fn from(err: std::str::Utf8Error) -> Self {
+        Self::Utf8(err)
+    }
 }
 
 impl From<wasmer::InstantiationError> for Error {

--- a/piecrust/src/session.rs
+++ b/piecrust/src/session.rs
@@ -13,7 +13,7 @@ use std::mem;
 use std::sync::Arc;
 
 use bytecheck::CheckBytes;
-use piecrust_uplink::{ContractId, Event, SCRATCH_BUF_BYTES};
+use piecrust_uplink::{ContractId, Event, ARGBUF_LEN, SCRATCH_BUF_BYTES};
 use rkyv::ser::serializers::{
     BufferScratch, BufferSerializer, CompositeSerializer,
 };
@@ -34,7 +34,7 @@ use crate::Error::{InitalizationError, PersistenceError};
 
 use call_stack::{CallStack, StackElement};
 
-const MAX_META_SIZE: usize = 65_536;
+const MAX_META_SIZE: usize = ARGBUF_LEN;
 pub const INIT_METHOD: &str = "init";
 
 unsafe impl Send for Session {}

--- a/piecrust/src/session.rs
+++ b/piecrust/src/session.rs
@@ -184,17 +184,18 @@ impl Session {
             }
         };
 
-        let constructor_arg = deploy_data.constructor_arg.map(|arg| {
+        let mut constructor_arg = None;
+        if let Some(arg) = deploy_data.constructor_arg {
             let mut sbuf = [0u8; SCRATCH_BUF_BYTES];
             let scratch = BufferScratch::new(&mut sbuf);
             let ser = BufferSerializer::new(&mut self.inner.buffer[..]);
             let mut ser = CompositeSerializer::new(ser, scratch, Infallible);
 
-            ser.serialize_value(arg).expect("Infallible");
+            ser.serialize_value(arg)?;
             let pos = ser.pos();
 
-            self.inner.buffer[0..pos].to_vec()
-        });
+            constructor_arg = Some(self.inner.buffer[0..pos].to_vec());
+        }
 
         let contract_id = deploy_data.contract_id.unwrap();
         self.do_deploy(
@@ -228,7 +229,7 @@ impl Session {
             contract_id,
             owner: owner.clone(),
         };
-        let metadata_bytes = Self::serialize_data(&contract_metadata);
+        let metadata_bytes = Self::serialize_data(&contract_metadata)?;
 
         self.inner
             .contract_session
@@ -312,7 +313,7 @@ impl Session {
         let ser = BufferSerializer::new(&mut self.inner.buffer[..]);
         let mut ser = CompositeSerializer::new(ser, scratch, Infallible);
 
-        ser.serialize_value(fn_arg).expect("Infallible");
+        ser.serialize_value(fn_arg)?;
         let pos = ser.pos();
 
         let receipt = self.call_raw(
@@ -542,7 +543,7 @@ impl Session {
         self.inner.data.get(name)
     }
 
-    pub fn serialize_data<V>(value: &V) -> Vec<u8>
+    pub fn serialize_data<V>(value: &V) -> Result<Vec<u8>, Error>
     where
         V: for<'a> Serialize<StandardBufSerializer<'a>>,
     {
@@ -554,11 +555,11 @@ impl Session {
 
         let mut serializer =
             StandardBufSerializer::new(ser, scratch, Infallible);
-        serializer.serialize_value(value).expect("Infallible");
+        serializer.serialize_value(value)?;
 
         let pos = serializer.pos();
 
-        buf[..pos].to_vec()
+        Ok(buf[..pos].to_vec())
     }
 
     /// Increment the call execution count.
@@ -778,7 +779,7 @@ pub struct CallReceipt<T> {
 }
 
 impl CallReceipt<Vec<u8>> {
-    /// Deserializes a `CallReceipt<Vec<u8>> into a `CallReceipt<T>` using
+    /// Deserializes a `CallReceipt<Vec<u8>>` into a `CallReceipt<T>` using
     /// `rkyv`.
     fn deserialize<T>(self) -> Result<CallReceipt<T>, Error>
     where
@@ -787,7 +788,7 @@ impl CallReceipt<Vec<u8>> {
             + for<'b> CheckBytes<DefaultValidator<'b>>,
     {
         let ta = check_archived_root::<T>(&self.data[..])?;
-        let data = ta.deserialize(&mut Infallible).expect("Infallible");
+        let data = ta.deserialize(&mut Infallible)?;
 
         Ok(CallReceipt {
             points_spent: self.points_spent,
@@ -864,14 +865,14 @@ pub struct SessionDataBuilder {
 }
 
 impl SessionDataBuilder {
-    pub fn insert<S, V>(mut self, name: S, value: V) -> Self
+    pub fn insert<S, V>(mut self, name: S, value: V) -> Result<Self, Error>
     where
         S: Into<Cow<'static, str>>,
         V: for<'a> Serialize<StandardBufSerializer<'a>>,
     {
-        let data = Session::serialize_data(&value);
+        let data = Session::serialize_data(&value)?;
         self.data.insert(name.into(), data);
-        self
+        Ok(self)
     }
 
     pub fn base(mut self, base: [u8; 32]) -> Self {

--- a/piecrust/tests/commit.rs
+++ b/piecrust/tests/commit.rs
@@ -341,7 +341,7 @@ fn concurrent_sessions() -> Result<(), Error> {
 fn make_session(vm: &VM) -> Result<(Session, ContractId), Error> {
     const HEIGHT: u64 = 29_000u64;
     let mut session =
-        vm.session(SessionData::builder().insert("height", HEIGHT))?;
+        vm.session(SessionData::builder().insert("height", HEIGHT)?)?;
     let contract_id = session.deploy(
         contract_bytecode!("everest"),
         ContractData::builder(OWNER),

--- a/piecrust/tests/everest.rs
+++ b/piecrust/tests/everest.rs
@@ -15,7 +15,7 @@ pub fn height() -> Result<(), Error> {
 
     const HEIGHT: u64 = 29_000u64;
     let mut session =
-        vm.session(SessionData::builder().insert("height", HEIGHT))?;
+        vm.session(SessionData::builder().insert("height", HEIGHT)?)?;
 
     let id = session.deploy(
         contract_bytecode!("everest"),


### PR DESCRIPTION
It is important to handle errors properly, especially when these errors occur due to possibly malicious entities - be it contract or callers - trying to attack a long lived instance of the virtual machine.

This PR does this by handling errors appropriately, in particular in the WASM imports.