### PR TITLE
uplink: add more comprehensive documentation

### DIFF
--- a/piecrust-uplink/CHANGELOG.md
+++ b/piecrust-uplink/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add more comprehensive documentation of the whole crate [#189]&[#190]
 - Add `feed` extern [#243]
 
 ### Changed
@@ -103,6 +104,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#201]: https://github.com/dusk-network/piecrust/issues/201
 [#199]: https://github.com/dusk-network/piecrust/issues/199
 [#192]: https://github.com/dusk-network/piecrust/issues/192
+[#190]: https://github.com/dusk-network/piecrust/issues/190
+[#189]: https://github.com/dusk-network/piecrust/issues/189
 [#174]: https://github.com/dusk-network/piecrust/issues/174
 [#139]: https://github.com/dusk-network/piecrust/issues/139
 [#136]: https://github.com/dusk-network/piecrust/issues/136

--- a/piecrust-uplink/Cargo.toml
+++ b/piecrust-uplink/Cargo.toml
@@ -20,3 +20,7 @@ dlmalloc = { version = "0.2", optional = true, features = ["global"] }
 [features]
 abi = []
 debug = []
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/piecrust-uplink/src/abi.rs
+++ b/piecrust-uplink/src/abi.rs
@@ -15,6 +15,7 @@ mod state;
 pub use state::*;
 
 #[cfg(feature = "debug")]
+#[cfg_attr(docsrs, doc(cfg(feature = "debug")))]
 mod debug;
 #[cfg(feature = "debug")]
 pub use debug::*;

--- a/piecrust-uplink/src/abi/state.rs
+++ b/piecrust-uplink/src/abi/state.rs
@@ -63,6 +63,7 @@ mod ext {
     }
 }
 
+/// Execute some code that the host provides under the given name.
 pub fn host_query<A, Ret>(name: &str, arg: A) -> Ret
 where
     A: for<'a> Serialize<StandardBufSerializer<'a>>,
@@ -268,10 +269,12 @@ pub fn caller() -> ContractId {
     })
 }
 
+/// Returns the points limit with which the contact was called.
 pub fn limit() -> u64 {
     unsafe { ext::limit() }
 }
 
+/// Returns the amount of points the contact has spent.
 pub fn spent() -> u64 {
     unsafe { ext::spent() }
 }

--- a/piecrust-uplink/src/lib.rs
+++ b/piecrust-uplink/src/lib.rs
@@ -4,13 +4,70 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+//! Piecrust Uplink is the crate for writing WASM smart contracts in Rust
+//! targeting the Piecrust virtual machine.
+//!
+//! A smart contract is a program exposing a collection of functions that
+//! operate on a shared state. These functions can perform a variety of
+//! operations, such as reading or modifying the state, or interacting with the
+//! host.
+//!
+//! # State Model and ABI
+//! Contracts targeting the Piecrust VM represent their state as a [WASM
+//! memory]. The contract is free to represent its data as it sees fit, and may
+//! allocate at will.
+//!
+//! To communicate with the host, both the contract and the host can
+//! emplace data in a special region of this memory called the argument buffer.
+//! The argument buffer is used as both the input from the host and as the
+//! output of the contract. All functions exposed by the contract must follow
+//! the convention:
+//!
+//! ```c
+//! // A function compatible with the piecrust ABI takes in the number of bytes
+//! // written by the host to the argument buffer and returns the number of
+//! // bytes written by the contract.
+//! uint32_t fname(uint32_t arg_len);
+//! ```
+//!
+//! The contract also has some functions available to it, offered by the host
+//! through WASM imports. Examples of these functions include, but are not
+//! limited to:
+//!
+//! - [`call`] to call another contract
+//! - [`emit`] to emit events
+//!
+//! The functions in this crate are wrappers around a particular way of calling
+//! the WASM imports. Take a look at the [externs] for a full view of what is
+//! available.
+//!
+//! # Examples
+//! Some of the contracts used for testing purposes function as good examples.
+//! Take a look at the [contracts/] directory.
+//!
+//! # Features
+//! By default, this crate will include no features and build only the types and
+//! functions available when the ABI is not present. To write a contract one
+//! must use the `abi` feature:
+//!
+//! - `abi` for writing contracts
+//! - `dlmalloc` to using the builtin allocator
+//! - `debug` for writing contracts with debug capabilities such as the
+//!   [`debug!`] macro, and logging panics to stdout
+//!
+//! [WASM memory]: https://wasmbyexample.dev/examples/webassembly-linear-memory/webassembly-linear-memory.rust.en-us.html
+//! [contracts/]: https://github.com/dusk-network/piecrust/tree/main/contracts
+//! [externs]: https://github.com/dusk-network/piecrust/blob/c2dadaa8dec210bdbbc72619a687eb8c6f693877/piecrust-uplink/src/abi/state.rs#L42-L64
+
 #![feature(lang_items)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(feature = "debug", feature(panic_info_message))]
 #![no_std]
 
 extern crate alloc;
 
 #[cfg(feature = "abi")]
+#[cfg_attr(docsrs, doc(cfg(feature = "abi")))]
 mod abi;
 #[cfg(feature = "abi")]
 pub use abi::*;

--- a/piecrust-uplink/src/types.rs
+++ b/piecrust-uplink/src/types.rs
@@ -18,6 +18,7 @@ use rkyv::{
 
 use crate::SCRATCH_BUF_BYTES;
 
+/// And event emitted by a contract.
 #[derive(
     Debug,
     Clone,

--- a/piecrust/src/lib.rs
+++ b/piecrust/src/lib.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-//! Piecrust VM for WASM smart-contract execution.
+//! Piecrust VM for WASM smart contract execution.
 //!
 //! A [`VM`] is instantiated by calling [`VM::new`] using a directory for
 //! storage of commits.

--- a/piecrust/src/store.rs
+++ b/piecrust/src/store.rs
@@ -666,7 +666,7 @@ fn delete_commit_dir<P: AsRef<Path>>(
 fn squash_commit<P: AsRef<Path>>(
     root_dir: P,
     root: Hash,
-    commit: &mut Commit,
+    commit: &Commit,
 ) -> io::Result<()> {
     let root_dir = root_dir.as_ref();
 


### PR DESCRIPTION
We add some crate level docs, ensuring the first page of `docs.rs` is not so barebones, and ensure all relevant functions have at least a small comment adorning them.

To be more explicit on the feature requirements of each function, we also add some compile-time shennanigans for us to detect when `docs.rs` is building our crate, to properly display the required features on each function and struct.

Resolves: #190
Resolves: #189
See-also: #195