### PR TITLE
Add contract validation

### DIFF
--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "feeder",
     "fibonacci",
     "host",
+    "invalid",
     "merkle",
     "metadata",
     "micro",

--- a/contracts/invalid/Cargo.toml
+++ b/contracts/invalid/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "invalid"
+version = "0.1.0"
+authors = [
+    "Eduardo Leegwater Simões <eduardo@dusk.network>",
+]
+edition = "2021"
+
+license = "MPL-2.0"
+
+[dependencies]
+piecrust-uplink = { path = "../../piecrust-uplink", features = ["abi", "dlmalloc"] }
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/contracts/invalid/src/lib.rs
+++ b/contracts/invalid/src/lib.rs
@@ -1,0 +1,9 @@
+#![no_std]
+
+#[allow(unused_imports)]
+use piecrust_uplink as uplink;
+
+#[no_mangle]
+fn bad_function(bad_arg: i64) -> i64 {
+    bad_arg
+}

--- a/piecrust-uplink/CHANGELOG.md
+++ b/piecrust-uplink/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add contract validation during deployment [#157]
 - Add more comprehensive documentation of the whole crate [#189]&[#190]
 - Add `feed` extern [#243]
 
@@ -109,6 +110,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#190]: https://github.com/dusk-network/piecrust/issues/190
 [#189]: https://github.com/dusk-network/piecrust/issues/189
 [#174]: https://github.com/dusk-network/piecrust/issues/174
+[#157]: https://github.com/dusk-network/piecrust/issues/157
 [#139]: https://github.com/dusk-network/piecrust/issues/139
 [#136]: https://github.com/dusk-network/piecrust/issues/136
 

--- a/piecrust-uplink/src/lib.rs
+++ b/piecrust-uplink/src/lib.rs
@@ -59,6 +59,7 @@
 //! [contracts/]: https://github.com/dusk-network/piecrust/tree/main/contracts
 //! [externs]: https://github.com/dusk-network/piecrust/blob/c2dadaa8dec210bdbbc72619a687eb8c6f693877/piecrust-uplink/src/abi/state.rs#L42-L64
 
+#![allow(internal_features)]
 #![feature(lang_items)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(feature = "debug", feature(panic_info_message))]

--- a/piecrust/src/error.rs
+++ b/piecrust/src/error.rs
@@ -45,6 +45,10 @@ pub enum Error {
     InitalizationError(Cow<'static, str>),
     #[error(transparent)]
     InstantiationError(Arc<wasmer::InstantiationError>),
+    #[error("Invalid global")]
+    InvalidArgumentBuffer,
+    #[error("Invalid memory")]
+    InvalidFunctionSignature(String),
     #[error(transparent)]
     MemorySetupError(Arc<std::io::Error>),
     #[error("Memory access out of bounds: offset {offset}, length {len}, memory length {mem_len}")]
@@ -73,6 +77,8 @@ pub enum Error {
     SerializeError(Arc<wasmer::SerializeError>),
     #[error("Session error: {0}")]
     SessionError(Cow<'static, str>),
+    #[error("Too many memories: {0}")]
+    TooManyMemories(usize),
     #[error("WASMER TRAP")]
     Trap(Arc<wasmer_vm::Trap>),
     #[error(transparent)]

--- a/piecrust/src/store.rs
+++ b/piecrust/src/store.rs
@@ -26,7 +26,7 @@ use flate2::Compression;
 
 pub use bytecode::Bytecode;
 use diff::diff;
-pub use memory::Memory;
+pub use memory::{Memory, MIN_MEM_SIZE};
 pub use metadata::Metadata;
 pub use objectcode::Objectcode;
 use piecrust_uplink::ContractId;

--- a/piecrust/src/store/memory.rs
+++ b/piecrust/src/store/memory.rs
@@ -29,7 +29,7 @@ use libc::{
 use crate::store::diff::patch;
 
 const WASM_MIN_PAGES: usize = 4;
-const MIN_MEM_SIZE: usize = WASM_PAGE_SIZE * WASM_MIN_PAGES;
+pub const MIN_MEM_SIZE: usize = WASM_PAGE_SIZE * WASM_MIN_PAGES;
 const MAX_MEM_SIZE: usize = WASM_PAGE_SIZE * WASM_MAX_PAGES as usize;
 
 #[derive(Debug)]

--- a/piecrust/tests/validation.rs
+++ b/piecrust/tests/validation.rs
@@ -27,3 +27,20 @@ fn out_of_bounds() -> Result<(), Error> {
 
     Ok(())
 }
+
+#[test]
+fn bad_contract() -> Result<(), Error> {
+    let vm = VM::ephemeral()?;
+
+    let mut session = vm.session(SessionData::builder())?;
+
+    let _ = session
+        .deploy(
+            contract_bytecode!("invalid"),
+            ContractData::builder(OWNER),
+            LIMIT,
+        )
+        .expect_err("Deploying an invalid contract should error");
+
+    Ok(())
+}


### PR DESCRIPTION
Contract validation is performed during deployment of the contract, to ensure no invalid contracts ever "hit" the state. The following rules are employed:

- Argument buffer fits in the memory
- There is only one memory, and it's called "memory
- Every exported function matches the `f: i32 -> i32` calling convention

Resolves #157 