### PR TITLE
Piecrust release `0.8.0`

### DIFF
--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2023-08-09
+
 ### Added
 
 - Add `Error::MemoryAccessOutOfBounds` [#249]
@@ -190,7 +192,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#93]: https://github.com/dusk-network/piecrust/issues/93
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/piecrust-0.8.0...HEAD
+[0.8.0]: https://github.com/dusk-network/piecrust/compare/v0.7.0...piecrust-0.8.0
 [0.7.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.6.2...v0.7.0
 [0.6.1]: https://github.com/dusk-network/piecrust/compare/piecrust-0.6.1...piecrust-0.6.2
 [0.6.1]: https://github.com/dusk-network/piecrust/compare/v0.6.0...piecrust-0.6.1

--- a/piecrust/Cargo.toml
+++ b/piecrust/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.8.0-rc.0"
+version = "0.8.0"
 
 edition = "2021"
 license = "MPL-2.0"


### PR DESCRIPTION
## [0.8.0] - 2023-08-09

### Added

- Add `Error::MemoryAccessOutOfBounds` [#249]
- Add `memmap2` dependency

### Changed

- Change imports 
- Change diffing algorithm to not delegate growth to `bsdiff`
- Change memory growth algorithm to not require copying to temp file

### Fixed

- Fix  behavior of imports on  out of bounds pointers [#249]
- Fix SIGBUS caused by improper memory growth

[0.8.0]: https://github.com/dusk-network/piecrust/compare/v0.7.0...piecrust-0.8.0