### PR TITLE
Release `crumbles` and `piecrust`

### DIFF
--- a/crumbles/CHANGELOG.md
+++ b/crumbles/CHANGELOG.md
@@ -7,5 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2023-08-30
+
+### Added
+
+- Initial release
+
 <!-- ISSUES -->
+
 <!-- VERSIONS -->
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/crumbles-0.1.0...HEAD
+[0.1.0]: https://github.com/dusk-network/piecrust/releases/tag/crumbles-0.1.0

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2023-08-30
+
 ### Changed
 
 - Change commit write behavior to  write dirty pages instead of diffs [#253]
@@ -205,7 +207,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#93]: https://github.com/dusk-network/piecrust/issues/93
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/piecrust-0.8.0...HEAD
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/piecrust-0.9.0...HEAD
+[0.9.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.8.0...piecrust-0.9.0
 [0.8.0]: https://github.com/dusk-network/piecrust/compare/v0.7.0...piecrust-0.8.0
 [0.7.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.6.2...v0.7.0
 [0.6.1]: https://github.com/dusk-network/piecrust/compare/piecrust-0.6.1...piecrust-0.6.2

--- a/piecrust/Cargo.toml
+++ b/piecrust/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.8.0"
+version = "0.9.0"
 
 edition = "2021"
 license = "MPL-2.0"


### PR DESCRIPTION
## [piecrust 0.9.0] - 2023-08-30

### Changed

- Change commit write behavior to  write dirty pages instead of diffs [#253]
- Change memory backend  to use `crumbles` instead of `libc` directly  [#253]

### Removed

- Remove `Session::squash_commit`  since it's irrelevant with the new commit behavior [#253]
- Remove `libc` dependency [#253]
- Remove `flate2` dependency [#253]
- Remove `qbsdiff` dependency [#253]

## [crumbles 0.1.0] - 2023-08-30

### Added

- Initial release

[piecrust 0.9.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.8.0...piecrust-0.9.0
[crumbles 0.1.0]: https://github.com/dusk-network/piecrust/releases/tag/crumbles-0.1.0