### PR TITLE
Hotfix `piecrust` and `crumbles`

### DIFF
--- a/crumbles/CHANGELOG.md
+++ b/crumbles/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2023-09-07
+
 ### Fixed
 
 - Fix memory protection on snapshotting functions
@@ -20,5 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- ISSUES -->
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/crumbles-0.1.0...HEAD
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/crumbles-0.1.1...HEAD
+[0.1.1]: https://github.com/dusk-network/piecrust/compare/crumbles-0.1.0...crumbles-0.1.1
 [0.1.0]: https://github.com/dusk-network/piecrust/releases/tag/crumbles-0.1.0

--- a/crumbles/Cargo.toml
+++ b/crumbles/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["data-structures", "memory-management"]
 keywords = ["memory", "snapshots", "page", "dirty"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.1.0"
+version = "0.1.1"
 
 edition = "2021"
 license = "MPL-2.0"

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] - 2023-09-07
+
 ### Changed
 
 - Remove re-execution in favor of micro-snapshots [#254]
@@ -216,7 +218,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#93]: https://github.com/dusk-network/piecrust/issues/93
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/piecrust-0.9.0...HEAD
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/piecrust-0.9.1...HEAD
+[0.9.1]: https://github.com/dusk-network/piecrust/compare/piecrust-0.9.0...piecrust-0.9.1
 [0.9.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.8.0...piecrust-0.9.0
 [0.8.0]: https://github.com/dusk-network/piecrust/compare/v0.7.0...piecrust-0.8.0
 [0.7.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.6.2...v0.7.0

--- a/piecrust/Cargo.toml
+++ b/piecrust/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.9.0"
+version = "0.9.1"
 
 edition = "2021"
 license = "MPL-2.0"


### PR DESCRIPTION
## [piecrust 0.9.1] - 2023-09-07

### Changed

- Remove re-execution in favor of micro-snapshots [#254]

### Fixed

- Fix non-existing memory directory when not modifying a contract

## [crumbles 0.1.1] - 2023-09-07

### Fixed

- Fix memory protection on snapshotting functions

[piecrust 0.9.1]: https://github.com/dusk-network/piecrust/compare/piecrust-0.9.0...piecrust-0.9.1
[crumbles 0.1.1]: https://github.com/dusk-network/piecrust/compare/crumbles-0.1.0...crumbles-0.1.1