### PR TITLE
Hotfix `crumbles` and `piecrust`

### DIFF
--- a/crumbles/CHANGELOG.md
+++ b/crumbles/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - 2023-09-07
+
 ### Added
 
 - Add `Mmap::set_len` function
@@ -26,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- ISSUES -->
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/crumbles-0.1.1...HEAD
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/crumbles-0.1.2...HEAD
+[0.1.2]: https://github.com/dusk-network/piecrust/compare/crumbles-0.1.1...crumbles-0.1.2
 [0.1.1]: https://github.com/dusk-network/piecrust/compare/crumbles-0.1.0...crumbles-0.1.1
 [0.1.0]: https://github.com/dusk-network/piecrust/releases/tag/crumbles-0.1.0

--- a/crumbles/Cargo.toml
+++ b/crumbles/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["data-structures", "memory-management"]
 keywords = ["memory", "snapshots", "page", "dirty"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.1.1"
+version = "0.1.2"
 
 edition = "2021"
 license = "MPL-2.0"

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## Changed
+## [0.9.2] - 2023-09-07
+
+### Changed
 
 - Change to use `crumbles::Mmap::set_len` on growing memory
 
@@ -222,7 +224,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#93]: https://github.com/dusk-network/piecrust/issues/93
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/piecrust-0.9.1...HEAD
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/piecrust-0.9.2...HEAD
+[0.9.2]: https://github.com/dusk-network/piecrust/compare/piecrust-0.9.1...piecrust-0.9.2
 [0.9.1]: https://github.com/dusk-network/piecrust/compare/piecrust-0.9.0...piecrust-0.9.1
 [0.9.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.8.0...piecrust-0.9.0
 [0.8.0]: https://github.com/dusk-network/piecrust/compare/v0.7.0...piecrust-0.8.0

--- a/piecrust/Cargo.toml
+++ b/piecrust/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.9.1"
+version = "0.9.2"
 
 edition = "2021"
 license = "MPL-2.0"


### PR DESCRIPTION
## [piecrust 0.9.2] - 2023-09-07

### Changed

- Change to use `crumbles::Mmap::set_len` on growing memory

## [crumbles 0.1.2] - 2023-09-07

### Added

- Add `Mmap::set_len` function


[piecrust 0.9.2]: https://github.com/dusk-network/piecrust/compare/piecrust-0.9.1...piecrust-0.9.2
[crumbles 0.1.2]: https://github.com/dusk-network/piecrust/compare/crumbles-0.1.1...crumbles-0.1.2