### PR TITLE
crumbles: fix file descriptor leak

### DIFF
--- a/crumbles/CHANGELOG.md
+++ b/crumbles/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix files passed to `Mmap::from_file` never being closed
+
 ## [0.1.2] - 2023-09-07
 
 ### Added

--- a/crumbles/src/lib.rs
+++ b/crumbles/src/lib.rs
@@ -47,7 +47,7 @@ use std::{
     fs::File,
     mem::{self, MaybeUninit},
     ops::{Deref, DerefMut},
-    os::fd::IntoRawFd,
+    os::fd::AsRawFd,
     sync::{Once, OnceLock, RwLock},
     {io, process, ptr, slice},
 };
@@ -456,7 +456,7 @@ impl MmapInner {
                     file_len,
                     PROT_READ,
                     MAP_PRIVATE | MAP_FIXED | MAP_NORESERVE,
-                    file.into_raw_fd(),
+                    file.as_raw_fd(),
                     0,
                 );
 


### PR DESCRIPTION
Small oversight in the usage of `File::into_raw_fd`, leading to files used by crumbles *never being closed*