### PR TITLE
crumbles: hotfix `0.1.3`

### DIFF
--- a/crumbles/CHANGELOG.md
+++ b/crumbles/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3] - 2023-09-11
+
 ### Fixed
 
 - Fix files passed to `Mmap::from_file` never being closed
@@ -32,7 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- ISSUES -->
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/crumbles-0.1.2...HEAD
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/crumbles-0.1.3...HEAD
+[0.1.3]: https://github.com/dusk-network/piecrust/compare/crumbles-0.1.2...crumbles-0.1.3
 [0.1.2]: https://github.com/dusk-network/piecrust/compare/crumbles-0.1.1...crumbles-0.1.2
 [0.1.1]: https://github.com/dusk-network/piecrust/compare/crumbles-0.1.0...crumbles-0.1.1
 [0.1.0]: https://github.com/dusk-network/piecrust/releases/tag/crumbles-0.1.0

--- a/crumbles/Cargo.toml
+++ b/crumbles/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["data-structures", "memory-management"]
 keywords = ["memory", "snapshots", "page", "dirty"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.1.2"
+version = "0.1.3"
 
 edition = "2021"
 license = "MPL-2.0"


### PR DESCRIPTION
## [0.1.3] - 2023-09-11

### Fixed

- Fix files passed to `Mmap::from_file` never being closed

[0.1.3]: https://github.com/dusk-network/piecrust/compare/crumbles-0.1.2...crumbles-0.1.3
