### PR TITLE
`piecrust` release `0.10.0`

### DIFF
--- a/crumbles/CHANGELOG.md
+++ b/crumbles/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2023-09-13
+
 ### Changed
 
 - Change `AsRef<[u8]>` and `AsMut<[u8]>` implementations for `Mmap` to always
@@ -46,7 +48,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- ISSUES -->
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/crumbles-0.1.3...HEAD
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/crumbles-0.2.0...HEAD
+[0.2.0]: https://github.com/dusk-network/piecrust/compare/crumbles-0.1.3...crumbles-0.2.0
 [0.1.3]: https://github.com/dusk-network/piecrust/compare/crumbles-0.1.2...crumbles-0.1.3
 [0.1.2]: https://github.com/dusk-network/piecrust/compare/crumbles-0.1.1...crumbles-0.1.2
 [0.1.1]: https://github.com/dusk-network/piecrust/compare/crumbles-0.1.0...crumbles-0.1.1

--- a/crumbles/Cargo.toml
+++ b/crumbles/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["data-structures", "memory-management"]
 keywords = ["memory", "snapshots", "page", "dirty"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.1.3"
+version = "0.2.0"
 
 edition = "2021"
 license = "MPL-2.0"

--- a/piecrust-uplink/CHANGELOG.md
+++ b/piecrust-uplink/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1] - 2023-09-13
+
 ### Added
 
 - Expose `arg_buf::with_arg_buf` to allow for custom argument buffer handling [#268]
@@ -120,7 +122,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#136]: https://github.com/dusk-network/piecrust/issues/136
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/uplink-0.7.1...HEAD
+[0.7.1]: https://github.com/dusk-network/piecrust/compare/v0.7.0...uplink-0.7.1
 [0.7.0]: https://github.com/dusk-network/piecrust/compare/uplink-0.6.1...v0.7.0
 [0.6.1]: https://github.com/dusk-network/piecrust/compare/v0.6.0...uplink-0.6.1
 [0.6.0]: https://github.com/dusk-network/piecrust/compare/v0.5.0...v0.6.0

--- a/piecrust-uplink/Cargo.toml
+++ b/piecrust-uplink/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.7.0"
+version = "0.7.1"
 
 edition = "2021"
 license = "MPL-2.0"

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2023-09-13
+
 ### Added
 
 - Add `Session::memory_len` to get the length of a memory in session [#268]
@@ -250,7 +252,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#93]: https://github.com/dusk-network/piecrust/issues/93
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/piecrust-0.9.2...HEAD
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/piecrust-0.10.0...HEAD
+[0.10.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.9.3...piecrust-0.10.0
 [0.9.3]: https://github.com/dusk-network/piecrust/compare/piecrust-0.9.2...piecrust-0.9.3
 [0.9.2]: https://github.com/dusk-network/piecrust/compare/piecrust-0.9.1...piecrust-0.9.2
 [0.9.1]: https://github.com/dusk-network/piecrust/compare/piecrust-0.9.0...piecrust-0.9.1

--- a/piecrust/Cargo.toml
+++ b/piecrust/Cargo.toml
@@ -7,13 +7,13 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.9.3"
+version = "0.10.0"
 
 edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-crumbles = { version = "0.1", path = "../crumbles" }
+crumbles = { version = "0.2", path = "../crumbles" }
 piecrust-uplink = { version = "0.7", path = "../piecrust-uplink" }
 
 wasmer = "=3.1"


### PR DESCRIPTION
## [piecrust 0.10.0] - 2023-09-13

### Added

- Add `Session::memory_len` to get the length of a memory in session [#268]

### Changed

- Change minimum number of pages to be 4
- Change reporting of memory to the host to be the total range of the memory
  mapping available

### Removed

- Fake guard pages are now removed

### Fixed

- Revert memory size on errors [#268]
- Fix reporting of memory size to `wasmer` [#268]

## [uplink 0.7.1] - 2023-09-13

### Added

- Expose `arg_buf::with_arg_buf` to allow for custom argument buffer handling [#268]

## [crumbles 0.2.0] - 2023-09-13

### Changed

- Change `AsRef<[u8]>` and `AsMut<[u8]>` implementations for `Mmap` to always
  return the entire mapping
- Change segfault handler to no longer handle "Out of Bounds", since rust
  already handles this correctly - with a panic

### Removed

- Remove `Mmap::set_len`
- Remove `len` field from `MmapInner`

[piecrust 0.10.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.9.3...piecrust-0.10.0
[uplink 0.7.1]: https://github.com/dusk-network/piecrust/compare/v0.7.0...uplink-0.7.1
[crumbles 0.2.0]: https://github.com/dusk-network/piecrust/compare/crumbles-0.1.3...crumbles-0.2.0

