### PR TITLE
Receive call tree after execution

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ members = [
     "piecrust-uplink",
     "piecrust",
 ]
+resolver = "2"

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -21,3 +21,4 @@ members = [
     "stack",
     "vector",
 ]
+resolver = "2"

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Rename `StackElement` to `CallTreeElem` [#206]
 - Allow for multiple initializations on a new memory [#271]
 - Downcast `Error::RuntimeError` on each call boundary [#271]
 

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Expose `CallTree` and `CallTreeElem` in the public API [#206]
 - Add `CallTreeIter` to improve iteration over call tree [#206]
 - Add `panic` import implementation [#271]
 - Add `Error::ContractPanic` variant [#271]

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `CallTreeIter` to improve iteration over call tree [#206]
 - Add `panic` import implementation [#271]
 - Add `Error::ContractPanic` variant [#271]
 
@@ -250,6 +251,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#216]: https://github.com/dusk-network/piecrust/issues/216
 [#213]: https://github.com/dusk-network/piecrust/issues/213
 [#207]: https://github.com/dusk-network/piecrust/issues/207
+[#206]: https://github.com/dusk-network/piecrust/issues/206
 [#202]: https://github.com/dusk-network/piecrust/issues/202
 [#201]: https://github.com/dusk-network/piecrust/issues/201
 [#181]: https://github.com/dusk-network/piecrust/issues/181

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `spent` field to `CallTreeElem` [#206]
 - Add `call_tree` to `CallReceipt` [#206]
 - Expose `CallTree` and `CallTreeElem` in the public API [#206]
 - Add `CallTreeIter` to improve iteration over call tree [#206]

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow for multiple initializations on a new memory [#271]
 - Downcast `Error::RuntimeError` on each call boundary [#271]
 
+### Removed
+
+- Remove `CallStack` in favor of `CallTree` [#206]
+
 ## [0.10.0] - 2023-09-13
 
 ### Added

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `call_tree` to `CallReceipt` [#206]
 - Expose `CallTree` and `CallTreeElem` in the public API [#206]
 - Add `CallTreeIter` to improve iteration over call tree [#206]
 - Add `panic` import implementation [#271]

--- a/piecrust/src/imports.rs
+++ b/piecrust/src/imports.rs
@@ -182,7 +182,7 @@ fn c(
 
     let ret = match instance.with_memory_mut(with_memory) {
         Ok((ret_len, callee_spent)) => {
-            env.move_up_call_tree();
+            env.move_up_call_tree(callee_spent);
             instance.set_remaining_points(caller_remaining - callee_spent);
             ret_len
         }

--- a/piecrust/src/imports.rs
+++ b/piecrust/src/imports.rs
@@ -182,7 +182,7 @@ fn c(
 
     let ret = match instance.with_memory_mut(with_memory) {
         Ok((ret_len, callee_spent)) => {
-            env.pop_callstack();
+            env.move_up_call_tree();
             instance.set_remaining_points(caller_remaining - callee_spent);
             ret_len
         }
@@ -193,7 +193,7 @@ fn c(
                     io: Arc::new(io_err),
                 };
             }
-            env.pop_callstack_prune();
+            env.move_up_prune_call_tree();
             instance.set_remaining_points(caller_remaining - callee_limit);
 
             ContractError::from(err).into()

--- a/piecrust/src/lib.rs
+++ b/piecrust/src/lib.rs
@@ -105,6 +105,7 @@
 
 #[macro_use]
 mod bytecode_macro;
+mod call_tree;
 mod contract;
 mod error;
 mod imports;
@@ -114,6 +115,7 @@ mod store;
 mod types;
 mod vm;
 
+pub use call_tree::{CallTree, CallTreeElem};
 pub use contract::{ContractData, ContractDataBuilder};
 pub use error::Error;
 pub use session::{CallReceipt, Session, SessionData};

--- a/piecrust/src/session.rs
+++ b/piecrust/src/session.rs
@@ -486,7 +486,7 @@ impl Session {
     }
 
     pub(crate) fn nth_from_top(&self, n: usize) -> Option<CallTreeElem> {
-        self.inner.call_tree.nth_up(n)
+        self.inner.call_tree.nth_parent(n)
     }
 
     /// Creates a new instance of the given contract, returning its memory
@@ -540,7 +540,7 @@ impl Session {
         Ok(self
             .inner
             .call_tree
-            .nth_up(0)
+            .nth_parent(0)
             .expect("We just pushed an element to the stack"))
     }
 

--- a/piecrust/src/session.rs
+++ b/piecrust/src/session.rs
@@ -4,8 +4,6 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-pub mod call_stack;
-
 use std::borrow::Cow;
 use std::collections::btree_map::Entry;
 use std::collections::BTreeMap;
@@ -24,15 +22,13 @@ use rkyv::{
 };
 use wasmer_types::WASM_PAGE_SIZE;
 
+use crate::call_tree::{CallTree, CallTreeElem};
 use crate::contract::{ContractData, ContractMetadata, WrappedContract};
+use crate::error::Error::{self, InitalizationError, PersistenceError};
 use crate::instance::WrappedInstance;
 use crate::store::{ContractSession, Objectcode};
 use crate::types::StandardBufSerializer;
 use crate::vm::HostQueries;
-use crate::Error;
-use crate::Error::{InitalizationError, PersistenceError};
-
-use call_stack::{CallTree, CallTreeElem};
 
 const MAX_META_SIZE: usize = ARGBUF_LEN;
 pub const INIT_METHOD: &str = "init";

--- a/piecrust/src/session.rs
+++ b/piecrust/src/session.rs
@@ -522,6 +522,7 @@ impl Session {
                 self.inner.call_tree.push(CallTreeElem {
                     contract_id,
                     limit,
+                    spent: 0,
                     mem_len: instance.mem_len(),
                 });
             }
@@ -530,6 +531,7 @@ impl Session {
                 self.inner.call_tree.push(CallTreeElem {
                     contract_id,
                     limit,
+                    spent: 0,
                     mem_len,
                 });
             }
@@ -542,8 +544,8 @@ impl Session {
             .expect("We just pushed an element to the stack"))
     }
 
-    pub(crate) fn move_up_call_tree(&mut self) {
-        if let Some(element) = self.inner.call_tree.move_up() {
+    pub(crate) fn move_up_call_tree(&mut self, spent: u64) {
+        if let Some(element) = self.inner.call_tree.move_up(spent) {
             self.update_instance_count(element.contract_id, false);
         }
     }
@@ -666,6 +668,7 @@ impl Session {
 
         let mut call_tree = CallTree::new();
         mem::swap(&mut self.inner.call_tree, &mut call_tree);
+        call_tree.update_spent(spent);
 
         Ok((ret, spent, call_tree))
     }

--- a/piecrust/src/session.rs
+++ b/piecrust/src/session.rs
@@ -32,7 +32,7 @@ use crate::vm::HostQueries;
 use crate::Error;
 use crate::Error::{InitalizationError, PersistenceError};
 
-use call_stack::{CallStack, StackElement};
+use call_stack::{CallStack, CallTreeElem};
 
 const MAX_META_SIZE: usize = ARGBUF_LEN;
 pub const INIT_METHOD: &str = "init";
@@ -488,7 +488,7 @@ impl Session {
         self.inner.host_queries.call(name, buf, arg_len)
     }
 
-    pub(crate) fn nth_from_top(&self, n: usize) -> Option<StackElement> {
+    pub(crate) fn nth_from_top(&self, n: usize) -> Option<CallTreeElem> {
         self.inner.call_stack.nth_from_top(n)
     }
 
@@ -516,13 +516,13 @@ impl Session {
         &mut self,
         contract_id: ContractId,
         limit: u64,
-    ) -> Result<StackElement, Error> {
+    ) -> Result<CallTreeElem, Error> {
         let instance = self.instance(&contract_id);
 
         match instance {
             Some(instance) => {
                 self.update_instance_count(contract_id, true);
-                self.inner.call_stack.push(StackElement {
+                self.inner.call_stack.push(CallTreeElem {
                     contract_id,
                     limit,
                     mem_len: instance.mem_len(),
@@ -530,7 +530,7 @@ impl Session {
             }
             None => {
                 let mem_len = self.create_instance(contract_id)?;
-                self.inner.call_stack.push(StackElement {
+                self.inner.call_stack.push(CallTreeElem {
                     contract_id,
                     limit,
                     mem_len,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2023-04-24"
+channel = "nightly-2023-08-24"
 targets = ["wasm32-unknown-unknown"]
 components = ["rust-src"]


### PR DESCRIPTION
Adds the call tree to the receipt of a call, allowing the host to understand which contract spent how much gas during the total execution. This tree can be iterated through, yielding `CallTreeElem` which contain various information about the call that was made. This also means code can be written downstream that branches on what each contract spent.

Resolves: #206