### PR TITLE
Return nothing from `owner` and `self_id`

### DIFF
--- a/piecrust-uplink/CHANGELOG.md
+++ b/piecrust-uplink/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add call to `panic` in panic handler [#271]
 - Add `panic` extern [#271]
 
+### Changed
+
+- Change return of `owner` and `self_id` to `()`
+
 ### Removed
 
 - Remove call to `hdebug` on panic [#271]

--- a/piecrust-uplink/src/abi/state.rs
+++ b/piecrust-uplink/src/abi/state.rs
@@ -13,7 +13,7 @@ use rkyv::{
 
 use crate::{
     ContractError, ContractId, RawCall, RawResult, StandardBufSerializer,
-    SCRATCH_BUF_BYTES,
+    CONTRACT_ID_BYTES, SCRATCH_BUF_BYTES,
 };
 
 pub mod arg_buf {
@@ -247,11 +247,12 @@ pub fn owner<const N: usize>() -> [u8; N] {
 /// Return the current contract's id.
 pub fn self_id() -> ContractId {
     unsafe { ext::self_id() };
-    let id: [u8; 32] = with_arg_buf(|buf| {
-        let ret = unsafe { archived_root::<[u8; 32]>(&buf[..32]) };
+    let id: ContractId = with_arg_buf(|buf| {
+        let ret =
+            unsafe { archived_root::<ContractId>(&buf[..CONTRACT_ID_BYTES]) };
         ret.deserialize(&mut Infallible).expect("Infallible")
     });
-    ContractId::from(id)
+    id
 }
 
 /// Return the ID of the calling contract. The returned id will be

--- a/piecrust-uplink/src/abi/state.rs
+++ b/piecrust-uplink/src/abi/state.rs
@@ -58,8 +58,8 @@ mod ext {
         pub fn caller();
         pub fn limit() -> u64;
         pub fn spent() -> u64;
-        pub fn owner() -> u32;
-        pub fn self_id() -> u32;
+        pub fn owner();
+        pub fn self_id();
     }
 }
 
@@ -80,7 +80,7 @@ where
         composite.pos() as u32
     });
 
-    let name_ptr = name.as_bytes().as_ptr() as *const u8;
+    let name_ptr = name.as_bytes().as_ptr();
     let name_len = name.as_bytes().len() as u32;
 
     let ret_len = unsafe { ext::hq(name_ptr, name_len, arg_len) };
@@ -237,18 +237,18 @@ where
 
 /// Return the current contract's owner.
 pub fn owner<const N: usize>() -> [u8; N] {
-    let len = unsafe { ext::owner() } as usize;
+    unsafe { ext::owner() };
     with_arg_buf(|buf| {
-        let ret = unsafe { archived_root::<[u8; N]>(&buf[..len]) };
+        let ret = unsafe { archived_root::<[u8; N]>(&buf[..N]) };
         ret.deserialize(&mut Infallible).expect("Infallible")
     })
 }
 
 /// Return the current contract's id.
 pub fn self_id() -> ContractId {
-    let len = unsafe { ext::self_id() } as usize;
+    unsafe { ext::self_id() };
     let id: [u8; 32] = with_arg_buf(|buf| {
-        let ret = unsafe { archived_root::<[u8; 32]>(&buf[..len]) };
+        let ret = unsafe { archived_root::<[u8; 32]>(&buf[..32]) };
         ret.deserialize(&mut Infallible).expect("Infallible")
     });
     ContractId::from(id)

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Change return of `owner` and `self_id` to `()`
 - Rename `StackElement` to `CallTreeElem` [#206]
 - Allow for multiple initializations on a new memory [#271]
 - Downcast `Error::RuntimeError` on each call boundary [#271]

--- a/piecrust/src/imports.rs
+++ b/piecrust/src/imports.rs
@@ -360,7 +360,7 @@ fn panic(fenv: FunctionEnvMut<Env>, arg_len: u32) -> Result<(), Error> {
     })
 }
 
-fn owner(fenv: FunctionEnvMut<Env>) -> u32 {
+fn owner(fenv: FunctionEnvMut<Env>) {
     let env = fenv.data();
     let self_id = env.self_contract_id();
     let contract_metadata = env
@@ -370,10 +370,9 @@ fn owner(fenv: FunctionEnvMut<Env>) -> u32 {
     let len = slice.len();
     env.self_instance()
         .with_arg_buffer(|arg| arg[..len].copy_from_slice(slice));
-    len as u32
 }
 
-fn self_id(fenv: FunctionEnvMut<Env>) -> u32 {
+fn self_id(fenv: FunctionEnvMut<Env>) {
     let env = fenv.data();
     let self_id = env.self_contract_id();
     let contract_metadata = env
@@ -383,5 +382,4 @@ fn self_id(fenv: FunctionEnvMut<Env>) -> u32 {
     let len = slice.len();
     env.self_instance()
         .with_arg_buffer(|arg| arg[..len].copy_from_slice(slice));
-    len as u32
 }


### PR DESCRIPTION
Given that the return is meant to be the length of what is written by the host in the argument buffer, and this length is fixed for both functions, it can safely be removed.