### PR TITLE
`crumbles`: support arbitrarily sized memory

### DIFF
--- a/crumbles/CHANGELOG.md
+++ b/crumbles/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Allow for choosing the size of the mapping
+
+### Changed
+
+- Change `Mmap::new` and `Mmap::with_files` to take `n_pages` and `page_size`
+
+### Removed
+
+- Remove `MEM_SIZE` and `PAGE_SIZE` constants
+
 ## [0.2.0] - 2023-09-13
 
 ### Changed

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Adapt to `crumbles` needing `n_pages` and `page_size`
 - Change return of `owner` and `self_id` to `()`
 - Rename `StackElement` to `CallTreeElem` [#206]
 - Allow for multiple initializations on a new memory [#271]

--- a/piecrust/src/instance.rs
+++ b/piecrust/src/instance.rs
@@ -22,7 +22,6 @@ use wasmer_types::{
 };
 use wasmer_vm::{LinearMemory, VMMemory, VMTable, VMTableDefinition};
 
-use crumbles::MEM_SIZE;
 use piecrust_uplink::{ContractId, Event, ARGBUF_LEN};
 
 use crate::contract::WrappedContract;
@@ -239,7 +238,7 @@ impl WrappedInstance {
         let memory_bytes = unsafe {
             let slice = view.data_unchecked();
             let ptr = slice.as_ptr();
-            slice::from_raw_parts(ptr, MEM_SIZE)
+            slice::from_raw_parts(ptr, MAX_MEM_SIZE)
         };
         f(memory_bytes)
     }
@@ -255,7 +254,7 @@ impl WrappedInstance {
         let memory_bytes = unsafe {
             let slice = view.data_unchecked_mut();
             let ptr = slice.as_mut_ptr();
-            slice::from_raw_parts_mut(ptr, MEM_SIZE)
+            slice::from_raw_parts_mut(ptr, MAX_MEM_SIZE)
         };
         f(memory_bytes)
     }

--- a/piecrust/src/store/tree.rs
+++ b/piecrust/src/store/tree.rs
@@ -7,11 +7,10 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use bytecheck::CheckBytes;
-use crumbles::PAGE_SIZE;
 use piecrust_uplink::ContractId;
 use rkyv::{Archive, Deserialize, Serialize};
 
-use crate::store::Memory;
+use crate::store::memory::{Memory, PAGE_SIZE};
 
 // There are `2^16` pages in a memory
 const P_HEIGHT: usize = 16;


### PR DESCRIPTION
`crumbles` now allows the user to specify the size of the mappings they require, as opposed to fixing the mappings to be tied to the 32-bit WASM specification - i.e. 64KiB page size and 64Ki pages. The user can now specify the logical size of the pages used by `crumbles::Mmap`, as well as their number. The page size has to be a multiple of the system page size, otherwise the dirty page tracking mechanism ceases to work.