### PR TITLE
Map each contract page lazily

### DIFF
--- a/crumbles/CHANGELOG.md
+++ b/crumbles/CHANGELOG.md
@@ -9,10 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `LocateFile` trait for getting file paths for mapping
 - Allow for choosing the size of the mapping
 
 ### Changed
 
+- Mapping behavior is now lazy, mapping pages to their regions on demand
+- Change `Mmap::with_files` to take `LocateFile` instead of `IntoIterator<Item = io::Result<(usize, File)>>`
 - Change `Mmap::new` and `Mmap::with_files` to take `n_pages` and `page_size`
 
 ### Removed

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Adapt to use `LocateFile` - `crumbles`'s lazy page loading mechanism
 - Adapt to `crumbles` needing `n_pages` and `page_size`
 - Change return of `owner` and `self_id` to `()`
 - Rename `StackElement` to `CallTreeElem` [#206]

--- a/piecrust/src/store/session.rs
+++ b/piecrust/src/store/session.rs
@@ -158,14 +158,29 @@ impl ContractSession {
 
                             let memory = match base_commit.index.get(&contract)
                             {
-                                Some(elem) => Memory::from_files(
-                                    elem.offsets.iter().map(|page_offset| {
-                                        let page_path = memory_path
-                                            .join(format!("{page_offset:08x}"));
-                                        (*page_offset, page_path)
-                                    }),
-                                    elem.len,
-                                )?,
+                                Some(elem) => {
+                                    let page_indices =
+                                        elem.page_indices.clone();
+                                    let memory_path = memory_path.clone();
+
+                                    Memory::from_files(
+                                        move |page_index: usize| {
+                                            match page_indices
+                                                .contains(&page_index)
+                                            {
+                                                true => {
+                                                    let page_path = memory_path
+                                                        .join(format!(
+                                                            "{page_index}"
+                                                        ));
+                                                    Some(page_path)
+                                                }
+                                                false => None,
+                                            }
+                                        },
+                                        elem.len,
+                                    )?
+                                }
                                 None => Memory::new()?,
                             };
 


### PR DESCRIPTION
This PR addresses an important scaling issue currently present with the page mapping mechanism.

Since there exists one file per contract page, and all pages must be accessible by the contract at any time, all files had to be iterated through and mapped to the address space region to be used as the contract's memory - *immediately* on first load. This will become a significant upfront cost for running a contract, especially once it becomes larger.

Here we introduce a mechanism where the pages are loaded on-demand, removing the upfront cost of loading a contract, and trading it in for more memory usage (2 bits per page).