### PR TITLE
Release `0.11.0`

### DIFF
--- a/crumbles/CHANGELOG.md
+++ b/crumbles/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2023-10-11
+
 ### Added
 
 - Add `LocateFile` trait for getting file paths for mapping
@@ -63,7 +65,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- ISSUES -->
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/crumbles-0.2.0...HEAD
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/crumbles-0.3.0...HEAD
+[0.3.0]: https://github.com/dusk-network/piecrust/compare/crumbles-0.2.0...crumbles-0.3.0
 [0.2.0]: https://github.com/dusk-network/piecrust/compare/crumbles-0.1.3...crumbles-0.2.0
 [0.1.3]: https://github.com/dusk-network/piecrust/compare/crumbles-0.1.2...crumbles-0.1.3
 [0.1.2]: https://github.com/dusk-network/piecrust/compare/crumbles-0.1.1...crumbles-0.1.2

--- a/crumbles/Cargo.toml
+++ b/crumbles/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["data-structures", "memory-management"]
 keywords = ["memory", "snapshots", "page", "dirty"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.2.0"
+version = "0.3.0"
 
 edition = "2021"
 license = "MPL-2.0"

--- a/piecrust-uplink/CHANGELOG.md
+++ b/piecrust-uplink/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2023-10-11
+
 ### Added
 
 - Add call to `panic` in panic handler [#271]
@@ -136,7 +138,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#136]: https://github.com/dusk-network/piecrust/issues/136
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/uplink-0.7.1...HEAD
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/uplink-0.8.0...HEAD
+[0.8.0]: https://github.com/dusk-network/piecrust/compare/uplink-0.7.1...uplink-0.8.0
 [0.7.1]: https://github.com/dusk-network/piecrust/compare/v0.7.0...uplink-0.7.1
 [0.7.0]: https://github.com/dusk-network/piecrust/compare/uplink-0.6.1...v0.7.0
 [0.6.1]: https://github.com/dusk-network/piecrust/compare/v0.6.0...uplink-0.6.1

--- a/piecrust-uplink/Cargo.toml
+++ b/piecrust-uplink/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.7.1"
+version = "0.8.0"
 
 edition = "2021"
 license = "MPL-2.0"

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2023-10-11
+
 ### Added
 
 - Add `spent` field to `CallTreeElem` [#206]
@@ -276,7 +278,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#93]: https://github.com/dusk-network/piecrust/issues/93
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/piecrust-0.10.0...HEAD
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/piecrust-0.11.0...HEAD
+[0.11.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.10.0...piecrust-0.11.0
 [0.10.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.9.3...piecrust-0.10.0
 [0.9.3]: https://github.com/dusk-network/piecrust/compare/piecrust-0.9.2...piecrust-0.9.3
 [0.9.2]: https://github.com/dusk-network/piecrust/compare/piecrust-0.9.1...piecrust-0.9.2

--- a/piecrust/Cargo.toml
+++ b/piecrust/Cargo.toml
@@ -7,14 +7,14 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.10.0"
+version = "0.11.0"
 
 edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-crumbles = { version = "0.2", path = "../crumbles" }
-piecrust-uplink = { version = "0.7", path = "../piecrust-uplink" }
+crumbles = { version = "0.3", path = "../crumbles" }
+piecrust-uplink = { version = "0.8", path = "../piecrust-uplink" }
 
 wasmer = "=3.1"
 wasmer-vm = "=3.1"


### PR DESCRIPTION
## [piecrust 0.11.0] - 2023-10-11

### Added

- Add `spent` field to `CallTreeElem` [#206]
- Add `call_tree` to `CallReceipt` [#206]
- Expose `CallTree` and `CallTreeElem` in the public API [#206]
- Add `CallTreeIter` to improve iteration over call tree [#206]
- Add `panic` import implementation [#271]
- Add `Error::ContractPanic` variant [#271]

### Changed

- Adapt to use `LocateFile` - `crumbles`'s lazy page loading mechanism
- Adapt to `crumbles` needing `n_pages` and `page_size`
- Change return of `owner` and `self_id` to `()`
- Rename `StackElement` to `CallTreeElem` [#206]
- Allow for multiple initializations on a new memory [#271]
- Downcast `Error::RuntimeError` on each call boundary [#271]

### Removed

- Remove `CallStack` in favor of `CallTree` [#206]

## [uplink 0.8.0] - 2023-10-11

### Added

- Add call to `panic` in panic handler [#271]
- Add `panic` extern [#271]

### Changed

- Change return of `owner` and `self_id` to `()`

### Removed

- Remove call to `hdebug` on panic [#271]

## [crumbles 0.3.0] - 2023-10-11

### Added

- Add `LocateFile` trait for getting file paths for mapping
- Allow for choosing the size of the mapping

### Changed

- Mapping behavior is now lazy, mapping pages to their regions on demand
- Change `Mmap::with_files` to take `LocateFile` instead of `IntoIterator<Item = io::Result<(usize, File)>>`
- Change `Mmap::new` and `Mmap::with_files` to take `n_pages` and `page_size`

[piecrust 0.11.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.10.0...piecrust-0.11.0
[uplink 0.8.0]: https://github.com/dusk-network/piecrust/compare/uplink-0.7.1...uplink-0.8.0
[crumbles 0.3.0]: https://github.com/dusk-network/piecrust/compare/crumbles-0.2.0...crumbles-0.3.0