### PR TITLE
Fix loading state from other archs

### DIFF
--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -41,6 +41,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * `SerializeError`
   * `Trap`
 
+## Fixed
+
+-  Fix  loading of compiled contracts from  state transported from different
+  platforms [#287]
+
 ## [0.11.0] - 2023-10-11
 
 ### Added
@@ -287,6 +292,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#234]: https://github.com/dusk-network/piecrust/pull/234
 
 <!-- ISSUES -->
+[#287]: https://github.com/dusk-network/piecrust/issues/287
 [#281]: https://github.com/dusk-network/piecrust/issues/281
 [#271]: https://github.com/dusk-network/piecrust/issues/271
 [#268]: https://github.com/dusk-network/piecrust/issues/268

--- a/piecrust/src/vm.rs
+++ b/piecrust/src/vm.rs
@@ -12,7 +12,8 @@ use std::sync::Arc;
 use std::thread;
 
 use dusk_wasmtime::{
-    Config, ModuleVersionStrategy, OptLevel, Strategy, WasmBacktraceDetails,
+    Config, Engine, ModuleVersionStrategy, OptLevel, Strategy,
+    WasmBacktraceDetails,
 };
 use tempfile::tempdir;
 
@@ -94,10 +95,17 @@ impl VM {
     /// # Errors
     /// If the directory contains unparseable or inconsistent data.
     pub fn new<P: AsRef<Path>>(root_dir: P) -> Result<Self, Error> {
-        let store = ContractStore::new(root_dir)
+        let config = config();
+
+        let engine = Engine::new(&config).expect(
+            "Configuration should be valid since its set at compile time",
+        );
+
+        let store = ContractStore::new(&engine, root_dir)
             .map_err(|err| PersistenceError(Arc::new(err)))?;
+
         Ok(Self {
-            config: config(),
+            config,
             host_queries: HostQueries::default(),
             store,
         })
@@ -114,11 +122,17 @@ impl VM {
         let tmp = tempdir().map_err(|err| PersistenceError(Arc::new(err)))?;
         let tmp = tmp.path().to_path_buf();
 
-        let store = ContractStore::new(tmp)
+        let config = config();
+
+        let engine = Engine::new(&config).expect(
+            "Configuration should be valid since its set at compile time",
+        );
+
+        let store = ContractStore::new(&engine, tmp)
             .map_err(|err| PersistenceError(Arc::new(err)))?;
 
         Ok(Self {
-            config: config(),
+            config,
             host_queries: HostQueries::default(),
             store,
         })


### PR DESCRIPTION
We do this by at `VM` instantiation time, checking if the module is correct for the native platform. If the module is not correct we compile it and write it back to disk. 

Resolves #287