### PR TITLE
Release `0.12.0`

### DIFF
--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2023-11-01
+
 ## Added
 
 - Support `memory64` smart contracts [#281]
@@ -320,7 +322,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#93]: https://github.com/dusk-network/piecrust/issues/93
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/piecrust-0.11.0...HEAD
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/piecrust-0.12.0...HEAD
+[0.12.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.11.0...piecrust-0.12.0
 [0.11.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.10.0...piecrust-0.11.0
 [0.10.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.9.3...piecrust-0.10.0
 [0.9.3]: https://github.com/dusk-network/piecrust/compare/piecrust-0.9.2...piecrust-0.9.3

--- a/piecrust/Cargo.toml
+++ b/piecrust/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.11.0"
+version = "0.12.0"
 
 edition = "2021"
 license = "MPL-2.0"


### PR DESCRIPTION
## [0.12.0] - 2023-11-01

## Added

- Support `memory64` smart contracts [#281]
- Add some `Error` variants:
  * `InvalidFunction`
  * `InvalidMemory`
- Add `once_cell` dependency

## Changed

- Upgrade `dusk-merkle` to version `0.5`
- Change contract tree to be arity 4 and height 17 [#159]
- Maximum contract size is now 4TiB [#159]
- Change `Error::RuntimeError` variant to contain `dusk_wasmtime::Error`,
  and changed `From` implementation
- Switch runtime from `wasmer` to `wasmtime`

## Removed

- Remove `parking_lot` dependency
- Remove `colored` dependency
- Remove 4 page - 256KiB - minimum memory requirement for contracts
- Remove `Clone` derivation for `Error`
- Remove some `Error` variants, along with `From` implementations:
  * `CompileError`
  * `DeserializeError`
  * `ExportError`
  * `InstantiationError`
  * `InvalidFunctionSignature`
  * `MemorySetupError`
  * `ParsingError`
  * `SerializeError`
  * `Trap`

## Fixed

-  Fix  loading of compiled contracts from  state transported from different
  platforms [#287]

[0.12.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.11.0...piecrust-0.12.0