### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,8 @@ jobs:
     runs-on: core
     steps:
       - uses: actions/checkout@v3
-      - uses: Swatinem/rust-cache@v2
+      - run: rustup self uninstall -y || true 
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: rustup target add wasm32-unknown-unknown
       - run: rustup component add rust-src
       - name: Run `make test`

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "nightly-2023-11-10"
 targets = ["wasm32-unknown-unknown"]
-components = ["rust-src", "rustfmt", "rustup", "cargo", "clippy"]
+components = ["rust-src", "rustfmt", "cargo", "clippy"]


### PR DESCRIPTION
Add fallback if a residual rustup install without a default toolchain breaks `setup-rust-toolchain`.