### PR TITLE
Fix improper use of mach_ports

### DIFF
--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -14,8 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change `Session::memory_len` to return `Result<Option<usize>>`, and not
   require a contract to be instantiated [#296]
 
+### Removed
+
+- Remove `once_cell` dependency
+
 ### Fixed
 
+- Fix improper use of mach_ports
 - Fix inconsistent state root after erroring call [#296]
 
 ## [0.13.0] - 2023-11-22

--- a/piecrust/Cargo.toml
+++ b/piecrust/Cargo.toml
@@ -19,7 +19,6 @@ piecrust-uplink = { version = "0.8", path = "../piecrust-uplink" }
 dusk-wasmtime = { version = "15", default-features = false, features = ["cranelift", "parallel-compilation"] }
 bytecheck = "0.6"
 rkyv = { version = "0.7", features = ["size_32", "validation"] }
-once_cell = "1.18"
 blake3 = "1"
 memmap2 = "0.7"
 tempfile = "3"
@@ -30,6 +29,7 @@ dusk-merkle = { version = "0.5", features = ["rkyv-impl"] }
 const-decoder = "0.3"
 
 [dev-dependencies]
+once_cell = "1.18"
 criterion = "0.4"
 dusk-plonk = { version = "0.14", features = ["rkyv-impl"] }
 

--- a/piecrust/src/vm.rs
+++ b/piecrust/src/vm.rs
@@ -78,11 +78,20 @@ fn config() -> Config {
 /// [`session`]: VM::session
 /// [`Deletions`]: VM::delete_commit
 /// [`sync_thread`]: VM::sync_thread
-#[derive(Debug)]
 pub struct VM {
-    config: Config,
+    engine: Engine,
     host_queries: HostQueries,
     store: ContractStore,
+}
+
+impl Debug for VM {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("VM")
+            .field("config", self.engine.config())
+            .field("host_queries", &self.host_queries)
+            .field("store", &self.store)
+            .finish()
+    }
 }
 
 impl VM {
@@ -101,11 +110,11 @@ impl VM {
             "Configuration should be valid since its set at compile time",
         );
 
-        let store = ContractStore::new(engine, root_dir)
+        let store = ContractStore::new(engine.clone(), root_dir)
             .map_err(|err| PersistenceError(Arc::new(err)))?;
 
         Ok(Self {
-            config,
+            engine,
             host_queries: HostQueries::default(),
             store,
         })
@@ -128,11 +137,11 @@ impl VM {
             "Configuration should be valid since its set at compile time",
         );
 
-        let store = ContractStore::new(engine, tmp)
+        let store = ContractStore::new(engine.clone(), tmp)
             .map_err(|err| PersistenceError(Arc::new(err)))?;
 
         Ok(Self {
-            config,
+            engine,
             host_queries: HostQueries::default(),
             store,
         })
@@ -171,7 +180,7 @@ impl VM {
             _ => self.store.genesis_session(),
         };
         Ok(Session::new(
-            self.config.clone(),
+            self.engine.clone(),
             contract_session,
             self.host_queries.clone(),
             data,


### PR DESCRIPTION
Using a dummy engine instantiated with the default configuration resulted in conflicting signal handling on MacOS. This commit fixes this problem, allowing MacOS users to run.