### PR TITLE
Allow contracts access to panic information

### DIFF
--- a/contracts/callcenter/src/lib.rs
+++ b/contracts/callcenter/src/lib.rs
@@ -8,9 +8,14 @@
 
 #![no_std]
 
+extern crate alloc;
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
 use piecrust_uplink as uplink;
 use piecrust_uplink::call_with_limit;
-use uplink::{wrap_call, ContractError, ContractId, RawCall, RawResult};
+use uplink::{wrap_call, ContractError, ContractId};
 
 /// Struct that describes the state of the Callcenter contract
 pub struct Callcenter;
@@ -33,25 +38,31 @@ impl Callcenter {
     pub fn delegate_query(
         &self,
         contract_id: ContractId,
-        raw: RawCall,
-    ) -> Result<RawResult, ContractError> {
-        uplink::debug!("raw query {:?} at {:?}", raw, contract_id);
-        uplink::call_raw(contract_id, &raw)
+        fn_name: String,
+        fn_arg: Vec<u8>,
+    ) -> Result<Vec<u8>, ContractError> {
+        uplink::debug!("raw query {fn_name} at {contract_id:?}");
+        uplink::call_raw(contract_id, &fn_name, &fn_arg)
     }
 
     /// Pass the current query
-    pub fn query_passthrough(&mut self, raw: RawCall) -> RawCall {
-        uplink::debug!("q passthrough {:?}", raw);
-        raw
+    pub fn query_passthrough(
+        &mut self,
+        fn_name: String,
+        fn_arg: Vec<u8>,
+    ) -> (String, Vec<u8>) {
+        uplink::debug!("q passthrough {fn_name}");
+        (fn_name, fn_arg)
     }
 
     /// Execute a contract specified by its ID
     pub fn delegate_transaction(
         &mut self,
         contract_id: ContractId,
-        raw: RawCall,
-    ) -> RawResult {
-        uplink::call_raw(contract_id, &raw).unwrap()
+        fn_name: String,
+        fn_arg: Vec<u8>,
+    ) -> Vec<u8> {
+        uplink::call_raw(contract_id, &fn_name, &fn_arg).unwrap()
     }
 
     /// Check whether the current caller is the contract itself
@@ -146,22 +157,24 @@ unsafe fn return_caller(arg_len: u32) -> u32 {
 /// Expose `Callcenter::delegate_query()` to the host
 #[no_mangle]
 unsafe fn delegate_query(arg_len: u32) -> u32 {
-    wrap_call(arg_len, |(mod_id, rq): (ContractId, RawCall)| {
-        STATE.delegate_query(mod_id, rq)
+    wrap_call(arg_len, |(mod_id, fn_name, fn_arg)| {
+        STATE.delegate_query(mod_id, fn_name, fn_arg)
     })
 }
 
 /// Expose `Callcenter::query_passthrough()` to the host
 #[no_mangle]
 unsafe fn query_passthrough(arg_len: u32) -> u32 {
-    wrap_call(arg_len, |rq: RawCall| STATE.query_passthrough(rq))
+    wrap_call(arg_len, |(fn_name, fn_arg)| {
+        STATE.query_passthrough(fn_name, fn_arg)
+    })
 }
 
 /// Expose `Callcenter::delegate_transaction()` to the host
 #[no_mangle]
 unsafe fn delegate_transaction(arg_len: u32) -> u32 {
-    wrap_call(arg_len, |(mod_id, rt): (ContractId, RawCall)| {
-        STATE.delegate_transaction(mod_id, rt)
+    wrap_call(arg_len, |(mod_id, fn_name, fn_arg)| {
+        STATE.delegate_transaction(mod_id, fn_name, fn_arg)
     })
 }
 

--- a/contracts/callcenter/src/lib.rs
+++ b/contracts/callcenter/src/lib.rs
@@ -100,8 +100,9 @@ impl Callcenter {
         contract: ContractId,
         points_limit: u64,
     ) -> Result<(), ContractError> {
-        call_with_limit(contract, "spend", &(), points_limit)?;
-        Ok(())
+        let res = call_with_limit(contract, "spend", &(), points_limit);
+        uplink::debug!("spend call: {res:?}");
+        res
     }
 
     /// Just panic.

--- a/contracts/spender/src/lib.rs
+++ b/contracts/spender/src/lib.rs
@@ -52,7 +52,7 @@ impl Spender {
     }
 
     /// Spend all points that are given to the contract.
-    pub fn spend() {
+    pub fn spend(&self) {
         panic!("I like spending");
     }
 }
@@ -61,4 +61,10 @@ impl Spender {
 #[no_mangle]
 unsafe fn get_limit_and_spent(a: u32) -> u32 {
     uplink::wrap_call(a, |_: ()| STATE.get_limit_and_spent())
+}
+
+/// Expose `Spender::spend()` to the host
+#[no_mangle]
+unsafe fn spend(a: u32) -> u32 {
+    uplink::wrap_call(a, |_: ()| STATE.spend())
 }

--- a/piecrust-uplink/CHANGELOG.md
+++ b/piecrust-uplink/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `fn_name` and `fn_arg` as an argument to `call_raw` and `call_raw_with_limit` [#301]
+
+### Removed
+
+- Remove `raw_call` as an argument of `call_raw` and `call_raw_with_limit` [#301]
+- Remove `RawCall` and `RawResult` [#301]
+
 ## [0.8.0] - 2023-10-11
 
 ### Added
@@ -120,6 +129,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - First `piecrust-uplink` release
 
 <!-- ISSUES -->
+[#301]: https://github.com/dusk-network/piecrust/issues/301
 [#271]: https://github.com/dusk-network/piecrust/issues/271
 [#268]: https://github.com/dusk-network/piecrust/issues/268
 [#243]: https://github.com/dusk-network/piecrust/issues/243

--- a/piecrust-uplink/CHANGELOG.md
+++ b/piecrust-uplink/CHANGELOG.md
@@ -9,10 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `ContractError::to_parts` and `ContractError::from_parts` functions [#301]
 - Add `fn_name` and `fn_arg` as an argument to `call_raw` and `call_raw_with_limit` [#301]
+
+### Changed
+
+- Rename `ContractError::Other` to `ContractError::Unknown` [#301]
+- Rename `ContractError::OutOfGas` to `ContractError::OutOfPoints` [#301]
+- Change `Display` for `ContractError` to display messages [#301]
+- Change `ContractError` variants to be CamelCase [#301]
 
 ### Removed
 
+- Remove `ContractError::from_code` function [#301]
 - Remove `raw_call` as an argument of `call_raw` and `call_raw_with_limit` [#301]
 - Remove `RawCall` and `RawResult` [#301]
 

--- a/piecrust-uplink/src/abi/state.rs
+++ b/piecrust-uplink/src/abi/state.rs
@@ -154,14 +154,14 @@ where
         )
     };
 
-    if ret_len < 0 {
-        return Err(ContractError::from_code(ret_len));
-    }
-
     with_arg_buf(|buf| {
-        let slice = &buf[..ret_len as usize];
-        let ret = unsafe { archived_root::<Ret>(slice) };
-        Ok(ret.deserialize(&mut Infallible).expect("Infallible"))
+        if ret_len < 0 {
+            Err(ContractError::from_parts(ret_len, buf))
+        } else {
+            let slice = &buf[..ret_len as usize];
+            let ret = unsafe { archived_root::<Ret>(slice) };
+            Ok(ret.deserialize(&mut Infallible).expect("Infallible"))
+        }
     })
 }
 
@@ -209,11 +209,13 @@ pub fn call_raw_with_limit(
         )
     };
 
-    if ret_len < 0 {
-        return Err(ContractError::from_code(ret_len));
-    }
-
-    with_arg_buf(|buf| Ok(buf[..ret_len as usize].to_vec()))
+    with_arg_buf(|buf| {
+        if ret_len < 0 {
+            Err(ContractError::from_parts(ret_len, buf))
+        } else {
+            Ok(buf[..ret_len as usize].to_vec())
+        }
+    })
 }
 
 /// Returns data made available by the host under the given name. The type `D`

--- a/piecrust-uplink/src/abi/state.rs
+++ b/piecrust-uplink/src/abi/state.rs
@@ -4,6 +4,8 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+use alloc::vec::Vec;
+
 use rkyv::{
     archived_root,
     ser::serializers::{BufferScratch, BufferSerializer, CompositeSerializer},
@@ -12,8 +14,8 @@ use rkyv::{
 };
 
 use crate::{
-    ContractError, ContractId, RawCall, RawResult, StandardBufSerializer,
-    CONTRACT_ID_BYTES, SCRATCH_BUF_BYTES,
+    ContractError, ContractId, StandardBufSerializer, CONTRACT_ID_BYTES,
+    SCRATCH_BUF_BYTES,
 };
 
 pub mod arg_buf {
@@ -140,10 +142,12 @@ where
         composite.pos() as u32
     });
 
+    let fn_name = fn_name.as_bytes();
+
     let ret_len = unsafe {
         ext::c(
             &contract.as_bytes()[0],
-            &fn_name.as_bytes()[0],
+            fn_name.as_ptr(),
             fn_name.len() as u32,
             arg_len,
             points_limit,
@@ -161,20 +165,21 @@ where
     })
 }
 
-/// Calls a `contract` with the given [`RawCall`]. The contract will have `93%`
-/// of the remaining points available to spend.
+/// Calls the function with name `fn_name` of the given `contract` using
+/// `fn_arg` as argument.
 ///
 /// To specify the points allowed to be spent by the called contract, use
 /// [`call_raw_with_limit`].
 pub fn call_raw(
     contract: ContractId,
-    raw_call: &RawCall,
-) -> Result<RawResult, ContractError> {
-    call_raw_with_limit(contract, raw_call, 0)
+    fn_name: &str,
+    fn_arg: &[u8],
+) -> Result<Vec<u8>, ContractError> {
+    call_raw_with_limit(contract, fn_name, fn_arg, 0)
 }
 
-/// Calls a `contract` with the given [`RawCall`] allowing it to spend the given
-/// `points_limit`.
+/// Calls the function with name `fn_name` of the given `contract` using
+/// `fn_arg` as argument, allowing it to spend the given `points_limit`.
 ///
 /// A point limit of `0` is equivalent to using [`call_raw`], and will use the
 /// default behavior - i.e. the called contract gets `93%` of the remaining
@@ -184,23 +189,22 @@ pub fn call_raw(
 /// default behavior will be used instead.
 pub fn call_raw_with_limit(
     contract: ContractId,
-    raw_call: &RawCall,
+    fn_name: &str,
+    fn_arg: &[u8],
     points_limit: u64,
-) -> Result<RawResult, ContractError> {
+) -> Result<Vec<u8>, ContractError> {
     with_arg_buf(|buf| {
-        let bytes = raw_call.arg_bytes();
-        buf[..bytes.len()].copy_from_slice(bytes);
+        buf[..fn_arg.len()].copy_from_slice(fn_arg);
     });
 
-    let fn_name = raw_call.name_bytes();
-    let fn_arg_len = raw_call.arg_bytes().len() as u32;
+    let fn_name = fn_name.as_bytes();
 
     let ret_len = unsafe {
         ext::c(
             &contract.as_bytes()[0],
-            &fn_name[0],
+            fn_name.as_ptr(),
             fn_name.len() as u32,
-            fn_arg_len,
+            fn_arg.len() as u32,
             points_limit,
         )
     };
@@ -209,7 +213,7 @@ pub fn call_raw_with_limit(
         return Err(ContractError::from_code(ret_len));
     }
 
-    with_arg_buf(|buf| Ok(RawResult::new(&buf[..ret_len as usize])))
+    with_arg_buf(|buf| Ok(buf[..ret_len as usize].to_vec()))
 }
 
 /// Returns data made available by the host under the given name. The type `D`

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Use `ContractError::to_parts` to write error messages to the argument buffer [#301]
+
 ### Changed
 
+- Rename `Error::ContractPanic` to `Error::Panic` to be more clear that the entire
+  execution panicked [#301]
 - Upgrade `dusk-wasmtime` to version `15`
 - De-instantiate modules after call [#296]
 - Change `Session::memory_len` to return `Result<Option<usize>>`, and not
@@ -320,6 +326,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#234]: https://github.com/dusk-network/piecrust/pull/234
 
 <!-- ISSUES -->
+[#301]: https://github.com/dusk-network/piecrust/issues/301
 [#296]: https://github.com/dusk-network/piecrust/issues/296
 [#287]: https://github.com/dusk-network/piecrust/issues/287
 [#281]: https://github.com/dusk-network/piecrust/issues/281

--- a/piecrust/src/error.rs
+++ b/piecrust/src/error.rs
@@ -5,7 +5,6 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use std::borrow::Cow;
-use std::convert::Infallible;
 use std::sync::{mpsc, Arc};
 use thiserror::Error;
 
@@ -62,8 +61,8 @@ pub enum Error {
     MissingHostQuery(String),
     #[error("OutOfPoints")]
     OutOfPoints,
-    #[error("Contract panic: {0}")]
-    ContractPanic(String),
+    #[error("Panic: {0}")]
+    Panic(String),
     #[error(transparent)]
     PersistenceError(Arc<std::io::Error>),
     #[error(transparent)]
@@ -93,7 +92,7 @@ impl Error {
 }
 
 impl From<std::convert::Infallible> for Error {
-    fn from(err: Infallible) -> Self {
+    fn from(err: std::convert::Infallible) -> Self {
         Self::Infallible(err)
     }
 }
@@ -122,14 +121,12 @@ impl<A, B> From<rkyv::validation::CheckArchiveError<A, B>> for Error {
     }
 }
 
-const OTHER_STATUS_CODE: i32 = i32::MIN;
-
 impl From<Error> for ContractError {
     fn from(err: Error) -> Self {
         match err {
-            Error::OutOfPoints => Self::OUTOFGAS,
-            Error::ContractPanic(_) => Self::PANIC,
-            _ => Self::OTHER(OTHER_STATUS_CODE),
+            Error::OutOfPoints => Self::OutOfPoints,
+            Error::Panic(msg) => Self::Panic(msg),
+            _ => Self::Unknown,
         }
     }
 }

--- a/piecrust/src/imports.rs
+++ b/piecrust/src/imports.rs
@@ -264,7 +264,11 @@ pub(crate) fn c(
             env.move_up_prune_call_tree();
             instance.set_remaining_points(caller_remaining - callee_limit);
 
-            ContractError::from(err).into()
+            let c_err = ContractError::from(err);
+            instance.with_arg_buf_mut(|buf| {
+                c_err.to_parts(buf);
+            });
+            c_err.into()
         }
     };
 
@@ -378,7 +382,7 @@ fn panic(fenv: Caller<Env>, arg_len: u32) -> WasmtimeResult<()> {
             Err(err) => return Err(Error::Utf8(err)),
         };
 
-        Err(Error::ContractPanic(msg.to_owned()))
+        Err(Error::Panic(msg.to_owned()))
     })?)
 }
 

--- a/piecrust/tests/counter.rs
+++ b/piecrust/tests/counter.rs
@@ -101,7 +101,7 @@ fn increment_panic() -> Result<(), Error> {
     )?;
 
     match session.call::<_, ()>(counter_id, "increment", &true, LIMIT) {
-        Err(Error::ContractPanic(panic_msg)) => {
+        Err(Error::Panic(panic_msg)) => {
             assert_eq!(panic_msg, String::from("Incremental panic"));
         }
         _ => panic!("Expected a panic error"),

--- a/piecrust/tests/spender.rs
+++ b/piecrust/tests/spender.rs
@@ -69,14 +69,26 @@ pub fn fails_with_out_of_points() -> Result<(), Error> {
 pub fn contract_sets_call_limit() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
-    let mut session = vm.session(SessionData::builder())?;
+    let mut session_1st = vm.session(SessionData::builder())?;
+    let mut session_2nd = vm.session(SessionData::builder())?;
 
-    let spender_id = session.deploy(
+    session_1st.deploy(
         contract_bytecode!("spender"),
         ContractData::builder(OWNER),
         LIMIT,
     )?;
-    let callcenter_id = session.deploy(
+    session_1st.deploy(
+        contract_bytecode!("callcenter"),
+        ContractData::builder(OWNER),
+        LIMIT,
+    )?;
+
+    let spender_id = session_2nd.deploy(
+        contract_bytecode!("spender"),
+        ContractData::builder(OWNER),
+        LIMIT,
+    )?;
+    let callcenter_id = session_2nd.deploy(
         contract_bytecode!("callcenter"),
         ContractData::builder(OWNER),
         LIMIT,
@@ -85,7 +97,7 @@ pub fn contract_sets_call_limit() -> Result<(), Error> {
     const FIRST_LIMIT: u64 = 1000;
     const SECOND_LIMIT: u64 = 2000;
 
-    let receipt = session.call::<_, Result<(), ContractError>>(
+    let receipt = session_1st.call::<_, Result<(), ContractError>>(
         callcenter_id,
         "call_spend_with_limit",
         &(spender_id, FIRST_LIMIT),
@@ -93,7 +105,7 @@ pub fn contract_sets_call_limit() -> Result<(), Error> {
     )?;
     let spent_first = receipt.points_spent;
 
-    let receipt = session.call::<_, Result<(), ContractError>>(
+    let receipt = session_2nd.call::<_, Result<(), ContractError>>(
         callcenter_id,
         "call_spend_with_limit",
         &(spender_id, SECOND_LIMIT),


### PR DESCRIPTION
This pull request enables a contract to access the reason behind a panic that occurs during an inter-contract call. It also includes enhancements to the inter-contract call functions, improving the clarity of arguments.

In specific updates, the enum variants of ContractError have been renamed to camel case. The Panic variant now includes a panic message as a String. The host ensures that this string is placed on the callee's argument buffer.

Resolves: #301