### PR TITLE
Change `points` terminology to `gas`

### DIFF
--- a/contracts/c-example/src/lib.rs
+++ b/contracts/c-example/src/lib.rs
@@ -21,7 +21,7 @@ mod ext {
             fn_name: *const u8,
             fn_name_len: u32,
             fn_arg_len: u32,
-            points_limit: u64,
+            gas_limit: u64,
         ) -> i32;
         pub fn hd(name: *const u8, name_len: u32) -> u32;
     }

--- a/contracts/callcenter/src/lib.rs
+++ b/contracts/callcenter/src/lib.rs
@@ -93,14 +93,14 @@ impl Callcenter {
     }
 
     /// Calls the `spend` function of the `contract` with no arguments, and the
-    /// given `points_limit`, assuming the called function returns `()`. It will
+    /// given `gas_limit`, assuming the called function returns `()`. It will
     /// then return the call's result itself.
     pub fn call_spend_with_limit(
         &self,
         contract: ContractId,
-        points_limit: u64,
+        gas_limit: u64,
     ) -> Result<(), ContractError> {
-        let res = call_with_limit(contract, "spend", &(), points_limit);
+        let res = call_with_limit(contract, "spend", &(), gas_limit);
         uplink::debug!("spend call: {res:?}");
         res
     }
@@ -138,8 +138,8 @@ unsafe fn call_self(arg_len: u32) -> u32 {
 /// Expose `Callcenter::call_spend_with_limit` to the host
 #[no_mangle]
 unsafe fn call_spend_with_limit(arg_len: u32) -> u32 {
-    wrap_call(arg_len, |(contract, points_limit)| {
-        STATE.call_spend_with_limit(contract, points_limit)
+    wrap_call(arg_len, |(contract, gas_limit)| {
+        STATE.call_spend_with_limit(contract, gas_limit)
     })
 }
 

--- a/contracts/spender/src/lib.rs
+++ b/contracts/spender/src/lib.rs
@@ -4,8 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-//! Contract for testing the gas spending behavior, where the gas is measured in
-//! WASM points.
+//! Contract for testing the gas spending behavior.
 
 #![no_std]
 
@@ -18,7 +17,7 @@ pub struct Spender;
 static mut STATE: Spender = Spender;
 
 impl Spender {
-    /// Get the limit and spent points before and after an inter-contract call,
+    /// Get the limit and spent gas before and after an inter-contract call,
     /// including the limit and spent by the called contract
     pub fn get_limit_and_spent(&self) -> (u64, u64, u64, u64, u64) {
         let self_id = uplink::self_id();
@@ -51,7 +50,7 @@ impl Spender {
         }
     }
 
-    /// Spend all points that are given to the contract.
+    /// Spend all gas that is given to the contract.
     pub fn spend(&self) {
         panic!("I like spending");
     }

--- a/piecrust-uplink/CHANGELOG.md
+++ b/piecrust-uplink/CHANGELOG.md
@@ -14,8 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Change variable names and documentation to match the `gas` terminology as
+  opposed to `points`
 - Rename `ContractError::Other` to `ContractError::Unknown` [#301]
-- Rename `ContractError::OutOfGas` to `ContractError::OutOfPoints` [#301]
 - Change `Display` for `ContractError` to display messages [#301]
 - Change `ContractError` variants to be CamelCase [#301]
 

--- a/piecrust-uplink/src/abi/state.rs
+++ b/piecrust-uplink/src/abi/state.rs
@@ -51,7 +51,7 @@ mod ext {
             fn_name: *const u8,
             fn_name_len: u32,
             fn_arg_len: u32,
-            points_limit: u64,
+            gas_limit: u64,
         ) -> i32;
 
         pub fn emit(topic: *const u8, topic_len: u32, arg_len: u32);
@@ -95,9 +95,9 @@ where
 }
 
 /// Calls a `contract`'s `fn_name` function with the given argument `fn_arg`.
-/// The contract will have `93%` of the remaining points available to spend.
+/// The contract will have `93%` of the remaining gas available to spend.
 ///
-/// To specify the points allowed to be spent by the called contract, use
+/// To specify the gas allowed to be spent by the called contract, use
 /// [`call_with_limit`].
 pub fn call<A, Ret>(
     contract: ContractId,
@@ -113,19 +113,18 @@ where
 }
 
 /// Calls a `contract`'s `fn_name` function with the given argument `fn_arg`,
-/// allowing it to spend the given `points_limit`.
+/// allowing it to spend the given `gas_limit`.
 ///
-/// A points limit of `0` is equivalent to using [`call`], and will use the
-/// default behavior - i.e. the called contract gets `93%` of the remaining
-/// points.
+/// A gas limit of `0` is equivalent to using [`call`], and will use the default
+/// behavior - i.e. the called contract gets `93%` of the remaining gas.
 ///
-/// If the points limit given is above or equal the remaining amount, the
-/// default behavior will be used instead.
+/// If the gas limit given is above or equal the remaining amount, the default
+/// behavior will be used instead.
 pub fn call_with_limit<A, Ret>(
     contract: ContractId,
     fn_name: &str,
     fn_arg: &A,
-    points_limit: u64,
+    gas_limit: u64,
 ) -> Result<Ret, ContractError>
 where
     A: for<'a> Serialize<StandardBufSerializer<'a>>,
@@ -150,7 +149,7 @@ where
             fn_name.as_ptr(),
             fn_name.len() as u32,
             arg_len,
-            points_limit,
+            gas_limit,
         )
     };
 
@@ -168,7 +167,7 @@ where
 /// Calls the function with name `fn_name` of the given `contract` using
 /// `fn_arg` as argument.
 ///
-/// To specify the points allowed to be spent by the called contract, use
+/// To specify the gas allowed to be spent by the called contract, use
 /// [`call_raw_with_limit`].
 pub fn call_raw(
     contract: ContractId,
@@ -179,19 +178,18 @@ pub fn call_raw(
 }
 
 /// Calls the function with name `fn_name` of the given `contract` using
-/// `fn_arg` as argument, allowing it to spend the given `points_limit`.
+/// `fn_arg` as argument, allowing it to spend the given `gas_limit`.
 ///
-/// A point limit of `0` is equivalent to using [`call_raw`], and will use the
-/// default behavior - i.e. the called contract gets `93%` of the remaining
-/// points.
+/// A gas limit of `0` is equivalent to using [`call_raw`], and will use the
+/// default behavior - i.e. the called contract gets `93%` of the remaining gas.
 ///
-/// If the points limit given is above or equal the remaining amount, the
-/// default behavior will be used instead.
+/// If the gas limit given is above or equal the remaining amount, the default
+/// behavior will be used instead.
 pub fn call_raw_with_limit(
     contract: ContractId,
     fn_name: &str,
     fn_arg: &[u8],
-    points_limit: u64,
+    gas_limit: u64,
 ) -> Result<Vec<u8>, ContractError> {
     with_arg_buf(|buf| {
         buf[..fn_arg.len()].copy_from_slice(fn_arg);
@@ -205,7 +203,7 @@ pub fn call_raw_with_limit(
             fn_name.as_ptr(),
             fn_name.len() as u32,
             fn_arg.len() as u32,
-            points_limit,
+            gas_limit,
         )
     };
 
@@ -276,12 +274,12 @@ pub fn caller() -> ContractId {
     })
 }
 
-/// Returns the points limit with which the contact was called.
+/// Returns the gas limit with which the contact was called.
 pub fn limit() -> u64 {
     unsafe { ext::limit() }
 }
 
-/// Returns the amount of points the contact has spent.
+/// Returns the amount of gas the contact has spent.
 pub fn spent() -> u64 {
     unsafe { ext::spent() }
 }

--- a/piecrust-uplink/src/error.rs
+++ b/piecrust-uplink/src/error.rs
@@ -26,7 +26,7 @@ use core::str;
 #[archive_attr(derive(CheckBytes))]
 pub enum ContractError {
     Panic(String),
-    OutOfPoints,
+    OutOfGas,
     Unknown,
 }
 
@@ -56,7 +56,7 @@ impl ContractError {
 
         match code {
             -1 => Self::Panic(get_msg(slice)),
-            -2 => Self::OutOfPoints,
+            -2 => Self::OutOfGas,
             i32::MIN => Self::Unknown,
             _ => unreachable!("The host must guarantee that the code is valid"),
         }
@@ -80,7 +80,7 @@ impl ContractError {
                 put_msg(msg, slice);
                 -1
             }
-            Self::OutOfPoints => -2,
+            Self::OutOfGas => -2,
             Self::Unknown => i32::MIN,
         }
     }
@@ -90,7 +90,7 @@ impl From<ContractError> for i32 {
     fn from(err: ContractError) -> Self {
         match err {
             ContractError::Panic(_) => -1,
-            ContractError::OutOfPoints => -2,
+            ContractError::OutOfGas => -2,
             ContractError::Unknown => i32::MIN,
         }
     }
@@ -100,7 +100,7 @@ impl Display for ContractError {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match self {
             ContractError::Panic(msg) => write!(f, "Panic: {msg}"),
-            ContractError::OutOfPoints => write!(f, "OutOfPoints"),
+            ContractError::OutOfGas => write!(f, "OutOfGas"),
             ContractError::Unknown => write!(f, "Unknown"),
         }
     }

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Change documentation to change terminology from `points` to `gas`
+- Rename `CallReceipt::points_limit` and `CallReceipt::points_spent` to
+  `CallReceipt::gas_limit` and `CallReceipt::gas_spent` respectively
+- Rename `Error::OutOfPoints` to `Error::OutOfGas`
 - Rename `Error::ContractPanic` to `Error::Panic` to be more clear that the entire
   execution panicked [#301]
 - Upgrade `dusk-wasmtime` to version `15`

--- a/piecrust/src/error.rs
+++ b/piecrust/src/error.rs
@@ -59,8 +59,8 @@ pub enum Error {
     MissingHostData(String),
     #[error("Missing host query: {0}")]
     MissingHostQuery(String),
-    #[error("OutOfPoints")]
-    OutOfPoints,
+    #[error("OutOfGas")]
+    OutOfGas,
     #[error("Panic: {0}")]
     Panic(String),
     #[error(transparent)]
@@ -124,7 +124,7 @@ impl<A, B> From<rkyv::validation::CheckArchiveError<A, B>> for Error {
 impl From<Error> for ContractError {
     fn from(err: Error) -> Self {
         match err {
-            Error::OutOfPoints => Self::OutOfPoints,
+            Error::OutOfGas => Self::OutOfGas,
             Error::Panic(msg) => Self::Panic(msg),
             _ => Self::Unknown,
         }

--- a/piecrust/src/imports/wasm32.rs
+++ b/piecrust/src/imports/wasm32.rs
@@ -32,7 +32,7 @@ pub(crate) fn c(
     name_ofs: u32,
     name_len: u32,
     arg_len: u32,
-    points_limit: u64,
+    gas_limit: u64,
 ) -> WasmtimeResult<i32> {
     imports::c(
         fenv,
@@ -40,7 +40,7 @@ pub(crate) fn c(
         name_ofs as usize,
         name_len,
         arg_len,
-        points_limit,
+        gas_limit,
     )
 }
 

--- a/piecrust/src/imports/wasm64.rs
+++ b/piecrust/src/imports/wasm64.rs
@@ -32,7 +32,7 @@ pub(crate) fn c(
     name_ofs: u64,
     name_len: u32,
     arg_len: u32,
-    points_limit: u64,
+    gas_limit: u64,
 ) -> WasmtimeResult<i32> {
     imports::c(
         fenv,
@@ -40,7 +40,7 @@ pub(crate) fn c(
         name_ofs as usize,
         name_len,
         arg_len,
-        points_limit,
+        gas_limit,
     )
 }
 

--- a/piecrust/src/instance.rs
+++ b/piecrust/src/instance.rs
@@ -280,17 +280,17 @@ impl WrappedInstance {
             .instance
             .get_typed_func::<u32, i32>(&mut self.store, method_name)?;
 
-        self.set_remaining_points(limit);
+        self.set_remaining_gas(limit);
 
         fun.call(&mut self.store, arg_len)
             .map_err(|e| map_call_err(self, e))
     }
 
-    pub fn set_remaining_points(&mut self, limit: u64) {
+    pub fn set_remaining_gas(&mut self, limit: u64) {
         self.store.set_fuel(limit).expect("Fuel is enabled");
     }
 
-    pub fn get_remaining_points(&mut self) -> u64 {
+    pub fn get_remaining_gas(&mut self) -> u64 {
         self.store.get_fuel().expect("Fuel is enabled")
     }
 
@@ -345,8 +345,8 @@ fn map_call_err(
     instance: &mut WrappedInstance,
     err: dusk_wasmtime::Error,
 ) -> Error {
-    if instance.get_remaining_points() == 0 {
-        return Error::OutOfPoints;
+    if instance.get_remaining_gas() == 0 {
+        return Error::OutOfGas;
     }
 
     err.into()

--- a/piecrust/src/lib.rs
+++ b/piecrust/src/lib.rs
@@ -16,11 +16,11 @@
 //! to the VM's directory - using [`commit`]. After a commit, the resulting
 //! state may be used by starting a new session with it as a base.
 //!
-//! Contract execution is metered in terms of `points`. The limit for the number
-//! of points used in a `call` or `deploy` is passed in their respective
-//! function signatures. If the limit is exceeded during the call an error will
-//! be returned. To learn more about the compiler middleware used to achieve
-//! this, please refer to the relevant [wasmer docs].
+//! Contract execution is metered in terms of `gas`. The limit for gas used in a
+//! `call` or `deploy` is passed in their respective function signatures. If the
+//! limit is exceeded during the call an error will be returned. To learn more
+//! about the compiler middleware used to achieve this, please refer to the
+//! relevant [runtime docs].
 //!
 //! # State Representation and Session/Commit Mechanism
 //!
@@ -106,7 +106,7 @@
 //! [`call`]: Session::call
 //! [`deploy`]: Session::deploy
 //! [`commit`]: Session::commit
-//! [wasmer docs]: wasmer_middlewares::metering
+//! [runtime docs]: dusk_wasmtime::Config::consume_fuel
 //! [`deletions`]: VM::delete_commit
 
 #[macro_use]

--- a/piecrust/tests/merkle.rs
+++ b/piecrust/tests/merkle.rs
@@ -20,13 +20,13 @@ pub fn merkle_root() -> Result<(), Error> {
         LIMIT,
     )?;
 
-    // (measured) minimum points to pass - insertion in a merkle tree is
+    // (measured) minimum gas to pass - insertion in a merkle tree is
     // "expensive".
-    const POINTS_LIMIT: u64 = 147456;
+    const GAS_LIMIT: u64 = 147456;
 
     let empty_root = [0u8; 32];
     let root: [u8; 32] = session
-        .call(id, "root", &(), POINTS_LIMIT)
+        .call(id, "root", &(), GAS_LIMIT)
         .expect("root query should succeed")
         .data;
 
@@ -45,7 +45,7 @@ pub fn merkle_root() -> Result<(), Error> {
                 .expect("tree insertion should succeed");
 
             *root = session
-                .call(id, "root", &(), POINTS_LIMIT)
+                .call(id, "root", &(), GAS_LIMIT)
                 .expect("root query should succeed")
                 .data;
         });

--- a/piecrust/tests/spender.rs
+++ b/piecrust/tests/spender.rs
@@ -11,7 +11,7 @@ const OWNER: [u8; 32] = [0u8; 32];
 const LIMIT: u64 = 1_000_000;
 
 #[test]
-pub fn points_get_used() -> Result<(), Error> {
+pub fn gas_get_used() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
     let mut session = vm.session(SessionData::builder())?;
@@ -29,7 +29,7 @@ pub fn points_get_used() -> Result<(), Error> {
 
     let receipt =
         session.call::<_, i64>(counter_id, "read_value", &(), LIMIT)?;
-    let counter_spent = receipt.points_spent;
+    let counter_spent = receipt.gas_spent;
 
     let receipt = session.call::<_, i64>(
         center_id,
@@ -37,7 +37,7 @@ pub fn points_get_used() -> Result<(), Error> {
         &counter_id,
         LIMIT,
     )?;
-    let center_spent = receipt.points_spent;
+    let center_spent = receipt.gas_spent;
 
     assert!(counter_spent < center_spent);
 
@@ -76,7 +76,7 @@ pub fn panic_msg_gets_through() -> Result<(), Error> {
 }
 
 #[test]
-pub fn fails_with_out_of_points() -> Result<(), Error> {
+pub fn fails_with_out_of_gas() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 
     let mut session = vm.session(SessionData::builder())?;
@@ -91,7 +91,7 @@ pub fn fails_with_out_of_points() -> Result<(), Error> {
         .call::<_, i64>(counter_id, "read_value", &(), 1)
         .expect_err("should error with no gas");
 
-    assert!(matches!(err, Error::OutOfPoints));
+    assert!(matches!(err, Error::OutOfGas));
 
     Ok(())
 }
@@ -134,7 +134,7 @@ pub fn contract_sets_call_limit() -> Result<(), Error> {
         &(spender_id, FIRST_LIMIT),
         LIMIT,
     )?;
-    let spent_first = receipt.points_spent;
+    let spent_first = receipt.gas_spent;
 
     let receipt = session_2nd.call::<_, Result<(), ContractError>>(
         callcenter_id,
@@ -142,7 +142,7 @@ pub fn contract_sets_call_limit() -> Result<(), Error> {
         &(spender_id, SECOND_LIMIT),
         LIMIT,
     )?;
-    let spent_second = receipt.points_spent;
+    let spent_second = receipt.gas_spent;
 
     assert_eq!(spent_second - spent_first, SECOND_LIMIT - FIRST_LIMIT);
 
@@ -172,7 +172,7 @@ pub fn limit_and_spent() -> Result<(), Error> {
 
     let (limit, spent_before, spent_after, called_limit, called_spent) =
         receipt.data;
-    let spender_spent = receipt.points_spent;
+    let spender_spent = receipt.gas_spent;
 
     assert_eq!(limit, LIMIT, "should be the initial limit");
 


### PR DESCRIPTION
There's been a lot of confusion on the difference between `points` and `gas`.

The theory was that we would use different terminology here, and that there would be a one-to-one relationship between gas and points upstream. This would also ensure that the implementer would be careful in translating points to actual value.

However, as the reader will no doubt notice, this constitutes unnecessary cognitive overhead for no tangible benefit. This is due to the fact that a layer of translation between gas and value has to exist regardless of whether the `points/gas` distinction exists or not.

Therefore this PR changes the entire nomenclature of the project to use `gas`, as opposed to `points`, effectively eliminating this overhead.