### PR TITLE
uplink: Bump to v0.9.0

### DIFF
--- a/piecrust-uplink/CHANGELOG.md
+++ b/piecrust-uplink/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2023-12-13
+
 ### Added
 
 - Add `ContractError::to_parts` and `ContractError::from_parts` functions [#301]
@@ -158,7 +160,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#136]: https://github.com/dusk-network/piecrust/issues/136
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/uplink-0.8.0...HEAD
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/uplink-0.9.0...HEAD
+[0.9.0]: https://github.com/dusk-network/piecrust/compare/uplink-0.8.0...uplink-0.9.0
 [0.8.0]: https://github.com/dusk-network/piecrust/compare/uplink-0.7.1...uplink-0.8.0
 [0.7.1]: https://github.com/dusk-network/piecrust/compare/v0.7.0...uplink-0.7.1
 [0.7.0]: https://github.com/dusk-network/piecrust/compare/uplink-0.6.1...v0.7.0

--- a/piecrust-uplink/Cargo.toml
+++ b/piecrust-uplink/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.9.0-rc.0"
+version = "0.9.0"
 
 edition = "2021"
 license = "MPL-2.0"


### PR DESCRIPTION
## [0.9.0] - 2023-12-13

### Added

- Add `ContractError::to_parts` and `ContractError::from_parts` functions [#301]
- Add `fn_name` and `fn_arg` as an argument to `call_raw` and `call_raw_with_limit` [#301]

### Changed

- Change variable names and documentation to match the `gas` terminology as
  opposed to `points`
- Rename `ContractError::Other` to `ContractError::Unknown` [#301]
- Change `Display` for `ContractError` to display messages [#301]
- Change `ContractError` variants to be CamelCase [#301]

### Removed

- Remove `ContractError::from_code` function [#301]
- Remove `raw_call` as an argument of `call_raw` and `call_raw_with_limit` [#301]
- Remove `RawCall` and `RawResult` [#301]

[0.9.0]: https://github.com/dusk-network/piecrust/compare/uplink-0.8.0...uplink-0.9.0
