### PR TITLE
piecrust: Bump to v0.14.0

### DIFF
--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2023-12-13
+
 ### Added
 
 - Use `ContractError::to_parts` to write error messages to the argument buffer [#301]
@@ -361,7 +363,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#93]: https://github.com/dusk-network/piecrust/issues/93
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/piecrust-0.13.0...HEAD
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/piecrust-0.14.0...HEAD
+[0.14.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.13.0...piecrust-0.14.0
 [0.13.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.12.0...piecrust-0.13.0
 [0.12.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.11.0...piecrust-0.12.0
 [0.11.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.10.0...piecrust-0.11.0

--- a/piecrust/Cargo.toml
+++ b/piecrust/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.14.0-rc.2"
+version = "0.14.0"
 
 edition = "2021"
 license = "MPL-2.0"


### PR DESCRIPTION
## [0.14.0] - 2023-12-13

### Added

- Use `ContractError::to_parts` to write error messages to the argument buffer [#301]

### Changed

- Change documentation to change terminology from `points` to `gas`
- Rename `CallReceipt::points_limit` and `CallReceipt::points_spent` to
  `CallReceipt::gas_limit` and `CallReceipt::gas_spent` respectively
- Rename `Error::OutOfPoints` to `Error::OutOfGas`
- Rename `Error::ContractPanic` to `Error::Panic` to be more clear that the entire
  execution panicked [#301]
- Upgrade `dusk-wasmtime` to version `15`
- De-instantiate modules after call [#296]
- Change `Session::memory_len` to return `Result<Option<usize>>`, and not
  require a contract to be instantiated [#296]

### Removed

- Remove `once_cell` dependency

### Fixed

- Fix improper use of mach_ports
- Fix inconsistent state root after erroring call [#296]


[0.14.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.13.0...piecrust-0.14.0
