### PR TITLE
Fix module recompilation

### DIFF
--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix module recompilation on invalid object code
+
 ## [0.14.0] - 2023-12-13
 
 ### Added

--- a/piecrust/src/store.rs
+++ b/piecrust/src/store.rs
@@ -227,19 +227,12 @@ fn commit_from_dir<P: AsRef<Path>>(
 
         let module_path = bytecode_path.with_extension(OBJECTCODE_EXTENSION);
 
-        if !module_path.is_file() {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("Non-existing module for contract: {contract_hex}"),
-            ));
-        }
-
         // SAFETY it is safe to deserialize the file here, since we don't use
         // the module here. We just want to check if the file is valid.
         if Module::from_file(engine, &module_path).is_err() {
             let bytecode = Bytecode::from_file(bytecode_path)?;
-            let module =
-                Module::new(engine, bytecode.as_ref()).map_err(|err| {
+            let module = Module::from_bytecode(engine, bytecode.as_ref())
+                .map_err(|err| {
                     io::Error::new(io::ErrorKind::InvalidData, err)
                 })?;
             fs::write(module_path, module.serialize())?;

--- a/piecrust/src/store/module.rs
+++ b/piecrust/src/store/module.rs
@@ -73,6 +73,23 @@ impl Module {
         Ok(Self { module })
     }
 
+    pub(crate) fn from_bytecode(
+        engine: &Engine,
+        bytecode: &[u8],
+    ) -> io::Result<Self> {
+        let module =
+            dusk_wasmtime::Module::new(engine, bytecode).map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("failed to compile module: {}", e),
+                )
+            })?;
+
+        check_single_memory(&module)?;
+
+        Ok(Self { module })
+    }
+
     pub(crate) fn serialize(&self) -> Vec<u8> {
         self.module
             .serialize()


### PR DESCRIPTION
Fixes recompiling the modules on VM instantiation when invalid ones are detected. This can happen in many circumstances, one of which is ingesting state produced under a different architecture or operating system.