### PR TITLE
Allow for querying a specific contract's owner

### DIFF
--- a/contracts/metadata/src/lib.rs
+++ b/contracts/metadata/src/lib.rs
@@ -20,12 +20,17 @@ static mut STATE: Metadata = Metadata;
 impl Metadata {
     /// Read the value of the contract's owner
     pub fn read_owner(&self) -> [u8; 33] {
-        uplink::owner()
+        uplink::self_owner()
     }
 
     /// Read the value of the contract's id
     pub fn read_id(&self) -> ContractId {
         uplink::self_id()
+    }
+
+    /// Read the value of the given contract's owner
+    pub fn read_owner_of(&self, id: ContractId) -> Option<[u8; 33]> {
+        uplink::owner(id)
     }
 }
 
@@ -39,4 +44,10 @@ unsafe fn read_owner(arg_len: u32) -> u32 {
 #[no_mangle]
 unsafe fn read_id(arg_len: u32) -> u32 {
     uplink::wrap_call(arg_len, |_: ()| STATE.read_id())
+}
+
+/// Expose `Metadata::read_owner_of()` to the host
+#[no_mangle]
+unsafe fn read_owner_of(arg_len: u32) -> u32 {
+    uplink::wrap_call(arg_len, |id| STATE.read_owner_of(id))
 }

--- a/piecrust-uplink/CHANGELOG.md
+++ b/piecrust-uplink/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `self_owner` function returning the owner of the calling contract
+
+### Changed
+
+- Change `owner` function to take a `ContractId` as argument and return an `Option<[u8; N]>`
+- Change `owner` extern to take a `*const u8` argument signifying the contract ID
+
 ## [0.9.0] - 2023-12-13
 
 ### Added

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change `owner` import to accept the contract ID as argument and return
+  non-zero upon success 
+
 ## [0.14.1] - 2024-01-11
 
 ### Fixed

--- a/piecrust/src/imports/wasm32.rs
+++ b/piecrust/src/imports/wasm32.rs
@@ -52,3 +52,7 @@ pub(crate) fn emit(
 ) -> WasmtimeResult<()> {
     imports::emit(fenv, topic_ofs as usize, topic_len, arg_len)
 }
+
+pub(crate) fn owner(fenv: Caller<Env>, mod_id_ofs: u32) -> WasmtimeResult<i32> {
+    imports::owner(fenv, mod_id_ofs as usize)
+}

--- a/piecrust/src/imports/wasm64.rs
+++ b/piecrust/src/imports/wasm64.rs
@@ -52,3 +52,7 @@ pub(crate) fn emit(
 ) -> WasmtimeResult<()> {
     imports::emit(fenv, topic_ofs as usize, topic_len, arg_len)
 }
+
+pub(crate) fn owner(fenv: Caller<Env>, mod_id_ofs: u64) -> WasmtimeResult<i32> {
+    imports::owner(fenv, mod_id_ofs as usize)
+}


### PR DESCRIPTION
Currently it is only possible for contract's to query for their own owners. This PR makes it possible for contract's to query for any other contract's owner as well.

This is achieved by modifying the `owner` import to accept a pointer to a contract ID in the calling contract's memory. If the passed pointer is non-null, the host reads the contract ID from the contract's memory, otherwise it is assumed to be the calling contract's.

If the contract queried for exists, its owner is emplaced in the calling contract's argument buffer, and 1 is returned, otherwise 0 is returned.  