### PR TITLE
Release `piecrust@0.15.0` and `piecrust-uplink@0.10.0`

### DIFF
--- a/piecrust-uplink/CHANGELOG.md
+++ b/piecrust-uplink/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2024-01-24
+
 ### Added
 
 - Add `self_owner` function returning the owner of the calling contract
@@ -169,7 +171,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#136]: https://github.com/dusk-network/piecrust/issues/136
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/uplink-0.9.0...HEAD
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/uplink-0.10.0...HEAD
+[0.10.0]: https://github.com/dusk-network/piecrust/compare/uplink-0.9.0...uplink-0.10.0
 [0.9.0]: https://github.com/dusk-network/piecrust/compare/uplink-0.8.0...uplink-0.9.0
 [0.8.0]: https://github.com/dusk-network/piecrust/compare/uplink-0.7.1...uplink-0.8.0
 [0.7.1]: https://github.com/dusk-network/piecrust/compare/v0.7.0...uplink-0.7.1

--- a/piecrust-uplink/Cargo.toml
+++ b/piecrust-uplink/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.10.0-rc.0"
+version = "0.10.0"
 
 edition = "2021"
 license = "MPL-2.0"

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2024-01-24
+
 ### Changed
 
 - Change `owner` import to accept the contract ID as argument and return
@@ -374,7 +376,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#93]: https://github.com/dusk-network/piecrust/issues/93
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/piecrust-0.14.1...HEAD
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/piecrust-0.15.0...HEAD
+[0.15.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.14.1...piecrust-0.15.0
 [0.14.1]: https://github.com/dusk-network/piecrust/compare/piecrust-0.14.0...piecrust-0.14.1
 [0.14.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.13.0...piecrust-0.14.0
 [0.13.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.12.0...piecrust-0.13.0

--- a/piecrust/Cargo.toml
+++ b/piecrust/Cargo.toml
@@ -7,14 +7,14 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.15.0-rc.0"
+version = "0.15.0"
 
 edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
 crumbles = { version = "0.3", path = "../crumbles" }
-piecrust-uplink = { version = "0.10.0-rc", path = "../piecrust-uplink" }
+piecrust-uplink = { version = "0.10", path = "../piecrust-uplink" }
 
 dusk-wasmtime = { version = "15", default-features = false, features = ["cranelift", "parallel-compilation"] }
 bytecheck = "0.6"


### PR DESCRIPTION
## [piecrust 0.15.0] - 2024-01-24

### Changed

- Change `owner` import to accept the contract ID as argument and return
  non-zero upon success

## [uplink 0.10.0] - 2024-01-24

### Added

- Add `self_owner` function returning the owner of the calling contract

### Changed

- Change `owner` function to take a `ContractId` as argument and return an `Option<[u8; N]>`
- Change `owner` extern to take a `*const u8` argument signifying the contract ID


[piecrust 0.15.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.14.1...piecrust-0.15.0
[uplink 0.10.0]: https://github.com/dusk-network/piecrust/compare/uplink-0.9.0...uplink-0.10.0
