### PR TITLE
Add bytecode migrations

### DIFF
--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "constructor",
     "counter",
     "debugger",
+    "double_counter",
     "eventer",
     "everest",
     "fallible_counter",

--- a/contracts/double_counter/Cargo.toml
+++ b/contracts/double_counter/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "double_counter"
+version = "0.1.0"
+authors = [
+    "Eduardo Leegwater Simões <eduardo@dusk.network>",
+]
+edition = "2021"
+
+license = "MPL-2.0"
+
+[dependencies]
+piecrust-uplink = { path = "../../piecrust-uplink", features = ["abi", "dlmalloc"] }
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/contracts/double_counter/src/lib.rs
+++ b/contracts/double_counter/src/lib.rs
@@ -1,0 +1,61 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+//! Contract to implement a simple double counter that can be read and
+//! have either value incremented by one count.
+
+#![no_std]
+
+use piecrust_uplink as uplink;
+
+/// Struct that describes the state of the DoubleCounter contract
+pub struct DoubleCounter {
+    left_value: i64,
+    right_value: i64,
+}
+
+/// State of the DoubleCounter contract
+static mut STATE: DoubleCounter = DoubleCounter {
+    left_value: 0xfc,
+    right_value: 0xcf,
+};
+
+impl DoubleCounter {
+    /// Read the value of the counter
+    pub fn read_values(&self) -> (i64, i64) {
+        (self.left_value, self.right_value)
+    }
+
+    /// Increment the value of the left counter by 1
+    pub fn increment_left(&mut self) {
+        let value = self.left_value + 1;
+        self.left_value = value;
+    }
+
+    /// Increment the value of the right counter by 1
+    pub fn increment_right(&mut self) {
+        let value = self.right_value + 1;
+        self.right_value = value;
+    }
+}
+
+/// Expose `Counter::read_value()` to the host
+#[no_mangle]
+unsafe fn read_values(arg_len: u32) -> u32 {
+    uplink::wrap_call(arg_len, |_: ()| STATE.read_values())
+}
+
+/// Expose `Counter::increment_left()` to the host
+#[no_mangle]
+unsafe fn increment_left(arg_len: u32) -> u32 {
+    uplink::wrap_call(arg_len, |_: ()| STATE.increment_left())
+}
+
+/// Expose `Counter::increment_right()` to the host
+#[no_mangle]
+unsafe fn increment_right(arg_len: u32) -> u32 {
+    uplink::wrap_call(arg_len, |_: ()| STATE.increment_right())
+}

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `Session::migrate` to allow for swapping contract code [#313]
+
 ## [0.15.0] - 2024-01-24
 
 ### Changed
@@ -345,6 +349,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#234]: https://github.com/dusk-network/piecrust/pull/234
 
 <!-- ISSUES -->
+[#301]: https://github.com/dusk-network/piecrust/issues/313
 [#301]: https://github.com/dusk-network/piecrust/issues/301
 [#296]: https://github.com/dusk-network/piecrust/issues/296
 [#287]: https://github.com/dusk-network/piecrust/issues/287

--- a/piecrust/src/store/session.rs
+++ b/piecrust/src/store/session.rs
@@ -27,6 +27,7 @@ pub struct ContractDataEntry {
     pub module: Module,
     pub metadata: Metadata,
     pub memory: Memory,
+    pub is_new: bool,
 }
 
 /// The representation of a session with a [`ContractStore`].
@@ -231,6 +232,7 @@ impl ContractSession {
                                     module,
                                     metadata,
                                     memory,
+                                    is_new: false,
                                 })
                                 .clone();
 
@@ -296,8 +298,30 @@ impl ContractSession {
                 module,
                 metadata,
                 memory,
+                is_new: true,
             },
         );
+
+        Ok(())
+    }
+
+    /// Remove the `old_contract` and move the `new_contract` to the
+    /// `old_contract`, effectively replacing the `old_contract` with
+    /// `new_contract`.
+    pub fn replace(
+        &mut self,
+        old_contract: ContractId,
+        new_contract: ContractId,
+    ) -> io::Result<()> {
+        let new_contract_data =
+            self.contracts.remove(&new_contract).ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("Contract '{new_contract}' not found"),
+                )
+            })?;
+
+        self.contracts.insert(old_contract, new_contract_data);
 
         Ok(())
     }

--- a/piecrust/src/store/tree.rs
+++ b/piecrust/src/store/tree.rs
@@ -158,6 +158,11 @@ impl ContractIndex {
             .insert(position_from_contract(&contract), *element.tree.root());
     }
 
+    pub fn remove_and_insert(&mut self, contract: ContractId, memory: &Memory) {
+        self.contracts.remove(&contract);
+        self.insert(contract, memory);
+    }
+
     pub fn root(&self) -> Ref<Hash> {
         self.tree.root()
     }


### PR DESCRIPTION
Bytecode migrations can now be performed using the `Session::migrate` function. This new function allows for passing in a closure that encodes a migration procedure. The procedure will have both contracts available in the state and is passed the new contract's temporary ID such that it can be called in just the same way as a regular contract. Once the procedure is executed without error the old contract is replaced with the new one and the session returned to the user.

Since it is possible that the `Session` is in an inconsistent state after an error in `Session::migrate`, the function takes the session by value, consuming it, and only returning it if no error was encountered.

Resolves: #313