### PR TITLE
support bytecheck-based integrity check of contract calls' arguments

### DIFF
--- a/contracts/counter/src/lib.rs
+++ b/contracts/counter/src/lib.rs
@@ -35,11 +35,11 @@ impl Counter {
 /// Expose `Counter::read_value()` to the host
 #[no_mangle]
 unsafe fn read_value(arg_len: u32) -> u32 {
-    uplink::wrap_call(arg_len, |_: ()| STATE.read_value())
+    uplink::wrap_call_unchecked(arg_len, |_: ()| STATE.read_value())
 }
 
 /// Expose `Counter::increment()` to the host
 #[no_mangle]
 unsafe fn increment(arg_len: u32) -> u32 {
-    uplink::wrap_call(arg_len, |_: ()| STATE.increment())
+    uplink::wrap_call_unchecked(arg_len, |_: ()| STATE.increment())
 }

--- a/piecrust-uplink/CHANGELOG.md
+++ b/piecrust-uplink/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `wrap_call_unchecked` function for calls with no argument checking [#324]
+
 ### Changed
 
 - Change `wrap_call` function to support `bytecheck`-based integrity check of arguments [#324]

--- a/piecrust-uplink/CHANGELOG.md
+++ b/piecrust-uplink/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change `wrap_call` function to support `bytecheck`-based integrity check of arguments [#324]
+
 ## [0.10.0] - 2024-01-24
 
 ### Added
@@ -152,6 +156,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - First `piecrust-uplink` release
 
 <!-- ISSUES -->
+[#324]: https://github.com/dusk-network/piecrust/issues/324
 [#301]: https://github.com/dusk-network/piecrust/issues/301
 [#271]: https://github.com/dusk-network/piecrust/issues/271
 [#268]: https://github.com/dusk-network/piecrust/issues/268

--- a/piecrust-uplink/Cargo.toml
+++ b/piecrust-uplink/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-rkyv = { version = "0.7", default-features = false, features = ["size_32", "alloc"] }
+rkyv = { version = "0.7", default-features = false, features = ["size_32", "alloc", "validation"] }
 bytecheck = { version = "0.6", default-features = false }
 dlmalloc = { version = "0.2", optional = true, features = ["global"] }
 

--- a/piecrust-uplink/src/abi/helpers.rs
+++ b/piecrust-uplink/src/abi/helpers.rs
@@ -12,11 +12,15 @@ use rkyv::ser::serializers::{
 };
 use rkyv::ser::Serializer;
 use rkyv::validation::validators::DefaultValidator;
-use rkyv::{check_archived_root, Archive, Deserialize, Infallible, Serialize};
+use rkyv::{
+    archived_root, check_archived_root, Archive, Deserialize, Infallible,
+    Serialize,
+};
 
 use crate::types::StandardBufSerializer;
 
 /// Wrap a call with its respective (de)serializers.
+/// Checks integrity of the arguments.
 ///
 /// Returns the length of result written to the buffer.
 pub fn wrap_call<A, R, F>(arg_len: u32, f: F) -> u32
@@ -32,6 +36,34 @@ where
 
         let aa: &A::Archived = check_archived_root::<A>(slice)
             .expect("Argument should correctly deserialize");
+        let a: A = aa.deserialize(&mut Infallible).unwrap();
+
+        let ret = f(a);
+
+        let mut sbuf = [0u8; SCRATCH_BUF_BYTES];
+        let scratch = BufferScratch::new(&mut sbuf);
+        let ser = BufferSerializer::new(buf);
+        let mut composite = CompositeSerializer::new(ser, scratch, Infallible);
+        composite.serialize_value(&ret).expect("infallible");
+        composite.pos() as u32
+    })
+}
+
+/// Wrap a call with its respective (de)serializers.
+/// Does not check the integrity of arguments.
+///
+/// Returns the length of result written to the buffer.
+pub fn wrap_call_unchecked<A, R, F>(arg_len: u32, f: F) -> u32
+where
+    A: Archive,
+    A::Archived: Deserialize<A, Infallible>,
+    R: for<'a> Serialize<StandardBufSerializer<'a>>,
+    F: Fn(A) -> R,
+{
+    with_arg_buf(|buf| {
+        let slice = &buf[..arg_len as usize];
+
+        let aa: &A::Archived = unsafe { archived_root::<A>(slice) };
         let a: A = aa.deserialize(&mut Infallible).unwrap();
 
         let ret = f(a);

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change `call` and `feeder_call` functions to support `bytecheck`-based integrity check of arguments [#324]
+
 ### Added
 
 - Add `Session::migrate` to allow for swapping contract code [#313]
@@ -360,6 +364,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- ISSUES -->
 [#325]: https://github.com/dusk-network/piecrust/issues/325
+[#324]: https://github.com/dusk-network/piecrust/issues/324
 [#301]: https://github.com/dusk-network/piecrust/issues/313
 [#301]: https://github.com/dusk-network/piecrust/issues/301
 [#296]: https://github.com/dusk-network/piecrust/issues/296

--- a/piecrust/src/session.rs
+++ b/piecrust/src/session.rs
@@ -339,6 +339,7 @@ impl Session {
     ) -> Result<CallReceipt<R>, Error>
     where
         A: for<'b> Serialize<StandardBufSerializer<'b>>,
+        A::Archived: for<'b> CheckBytes<DefaultValidator<'b>>,
         R: Archive,
         R::Archived: Deserialize<R, Infallible>
             + for<'b> CheckBytes<DefaultValidator<'b>>,
@@ -462,6 +463,7 @@ impl Session {
     ) -> Result<CallReceipt<R>, Error>
     where
         A: for<'b> Serialize<StandardBufSerializer<'b>>,
+        A::Archived: for<'b> CheckBytes<DefaultValidator<'b>>,
         R: Archive,
         R::Archived: Deserialize<R, Infallible>
             + for<'b> CheckBytes<DefaultValidator<'b>>,

--- a/piecrust/tests/spender.rs
+++ b/piecrust/tests/spender.rs
@@ -64,7 +64,7 @@ pub fn panic_msg_gets_through() -> Result<(), Error> {
     let receipt = session.call::<_, Result<(), ContractError>>(
         callcenter_id,
         "call_spend_with_limit",
-        &(spender_id, 1000u64),
+        &(spender_id, 1175u64),
         LIMIT,
     )?;
 
@@ -125,8 +125,8 @@ pub fn contract_sets_call_limit() -> Result<(), Error> {
         LIMIT,
     )?;
 
-    const FIRST_LIMIT: u64 = 1000;
-    const SECOND_LIMIT: u64 = 2000;
+    const FIRST_LIMIT: u64 = 1175;
+    const SECOND_LIMIT: u64 = 2175;
 
     let receipt = session_1st.call::<_, Result<(), ContractError>>(
         callcenter_id,


### PR DESCRIPTION
Support bytecheck-based integrity check of contract calls' arguments,

Implements issue #324
