### PR TITLE
Release 0.16.0

### DIFF
--- a/piecrust-uplink/CHANGELOG.md
+++ b/piecrust-uplink/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2024-02-14
+
 ### Added
 
 - Add `wrap_call_unchecked` function for calls with no argument checking [#324]
@@ -180,7 +182,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#136]: https://github.com/dusk-network/piecrust/issues/136
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/uplink-0.10.0...HEAD
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/uplink-0.11.0...HEAD
+[0.11.0]: https://github.com/dusk-network/piecrust/compare/uplink-0.10.0...uplink-0.11.0
 [0.10.0]: https://github.com/dusk-network/piecrust/compare/uplink-0.9.0...uplink-0.10.0
 [0.9.0]: https://github.com/dusk-network/piecrust/compare/uplink-0.8.0...uplink-0.9.0
 [0.8.0]: https://github.com/dusk-network/piecrust/compare/uplink-0.7.1...uplink-0.8.0

--- a/piecrust-uplink/Cargo.toml
+++ b/piecrust-uplink/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.11.0-rc.1"
+version = "0.11.0"
 
 edition = "2021"
 license = "MPL-2.0"

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0] - 2024-02-14
+
 ### Changed
 
 - Change `call` and `feeder_call` functions to support `bytecheck`-based integrity check of arguments [#324]
@@ -395,7 +397,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#93]: https://github.com/dusk-network/piecrust/issues/93
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/piecrust-0.15.0...HEAD
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/piecrust-0.16.0...HEAD
+[0.16.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.15.0...piecrust-0.16.0
 [0.15.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.14.1...piecrust-0.15.0
 [0.14.1]: https://github.com/dusk-network/piecrust/compare/piecrust-0.14.0...piecrust-0.14.1
 [0.14.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.13.0...piecrust-0.14.0

--- a/piecrust/Cargo.toml
+++ b/piecrust/Cargo.toml
@@ -7,14 +7,14 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.16.0-rc.1"
+version = "0.16.0"
 
 edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
 crumbles = { version = "0.3", path = "../crumbles" }
-piecrust-uplink = { version = "0.11.0-rc.1", path = "../piecrust-uplink" }
+piecrust-uplink = { version = "0.11", path = "../piecrust-uplink" }
 
 dusk-wasmtime = { version = "17", default-features = false, features = ["cranelift", "parallel-compilation"] }
 bytecheck = "0.6"


### PR DESCRIPTION
## [piecrust 0.16.0] - 2024-02-14

### Changed

- Change `call` and `feeder_call` functions to support `bytecheck`-based integrity check of arguments [#324]

### Added

- Add `Session::migrate` to allow for swapping contract code [#313]

### Changed

- Upgrade `dusk-wasmtime` to version `17`

### Fixed

- Fix overflow in gas limit calculation in inter-contract call

## [uplink 0.11.0] - 2024-02-14

### Added

- Add `wrap_call_unchecked` function for calls with no argument checking [#324]

### Changed

- Change `wrap_call` function to support `bytecheck`-based integrity check of arguments [#324]

## [uplink 0.10.0] - 2024-01-24

### Added

- Add `self_owner` function returning the owner of the calling contract

[piecrust 0.16.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.15.0...piecrust-0.16.0
[uplink 0.11.0]: https://github.com/dusk-network/piecrust/compare/uplink-0.10.0...uplink-0.11.0
