### PR TITLE
piecrust: optional owner in `Session::migrate`

### DIFF
--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `ContractDataBuilder::owner` to allow for setting the owner of a contract
+  on deploy time [#336]
+
 ### Changed
 
+- Make `owner` field optional in `ContractData` and `ContractDataBuilder` [#336]
 - Change `ContractData` and `ContractDataBuilder` to take a `Vec<u8>` as owner
   instead of `[u8; N]` [#336]
 - Use empty constructor arguments by default [#316]

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Change `migrate` to take the owner of the contract being replaced if it is
+  not set by the caller [#336]
 - Make `owner` field optional in `ContractData` and `ContractDataBuilder` [#336]
 - Change `ContractData` and `ContractDataBuilder` to take a `Vec<u8>` as owner
   instead of `[u8; N]` [#336]

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Change `ContractData` and `ContractDataBuilder` to take a `Vec<u8>` as owner
+  instead of `[u8; N]` [#336]
 - Use empty constructor arguments by default [#316]
 - Upgrade `dusk-wasmtime` to version `18`
 
@@ -32,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Change `owner` import to accept the contract ID as argument and return
-  non-zero upon success 
+  non-zero upon success
 
 ## [0.14.1] - 2024-01-11
 
@@ -72,11 +74,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 
-- Add `Session::memory_pages` allowing for inclusion  proofs of pages [#273]
+- Add `Session::memory_pages` allowing for inclusion proofs of pages [#273]
 
 ## Changed
 
-- Change state tree to  distinguish between 32 and 64 bit smart contracts [#273]
+- Change state tree to distinguish between 32 and 64 bit smart contracts [#273]
 
 ## [0.12.0] - 2023-11-01
 
@@ -84,8 +86,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support `memory64` smart contracts [#281]
 - Add some `Error` variants:
-  * `InvalidFunction`
-  * `InvalidMemory`
+    * `InvalidFunction`
+    * `InvalidMemory`
 - Add `once_cell` dependency
 
 ## Changed
@@ -104,19 +106,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove 4 page - 256KiB - minimum memory requirement for contracts
 - Remove `Clone` derivation for `Error`
 - Remove some `Error` variants, along with `From` implementations:
-  * `CompileError`
-  * `DeserializeError`
-  * `ExportError`
-  * `InstantiationError`
-  * `InvalidFunctionSignature`
-  * `MemorySetupError`
-  * `ParsingError`
-  * `SerializeError`
-  * `Trap`
+    * `CompileError`
+    * `DeserializeError`
+    * `ExportError`
+    * `InstantiationError`
+    * `InvalidFunctionSignature`
+    * `MemorySetupError`
+    * `ParsingError`
+    * `SerializeError`
+    * `Trap`
 
 ## Fixed
 
--  Fix  loading of compiled contracts from  state transported from different
+- Fix loading of compiled contracts from state transported from different
   platforms [#287]
 
 ## [0.11.0] - 2023-10-11
@@ -190,8 +192,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Change commit write behavior to  write dirty pages instead of diffs [#253]
-- Change memory backend  to use `crumbles` instead of `libc` directly  [#253]
+- Change commit write behavior to write dirty pages instead of diffs [#253]
+- Change memory backend to use `crumbles` instead of `libc` directly  [#253]
 
 ### Removed
 
@@ -209,13 +211,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Change imports 
+- Change imports
 - Change diffing algorithm to not delegate growth to `bsdiff`
 - Change memory growth algorithm to not require copying to temp file
 
 ### Fixed
 
-- Fix  behavior of imports on  out of bounds pointers [#249]
+- Fix behavior of imports on out of bounds pointers [#249]
 - Fix SIGBUS caused by improper memory growth
 
 ## [0.7.0] - 2023-07-19
@@ -310,7 +312,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Change `owner` parameter type in `ModuleData::builder` to be `[u8; N]` [#201] 
+- Change `owner` parameter type in `ModuleData::builder` to be `[u8; N]` [#201]
 
 ### Fixed
 
@@ -362,9 +364,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - First `piecrust` release
 
 <!-- PULLS -->
+
 [#234]: https://github.com/dusk-network/piecrust/pull/234
 
 <!-- ISSUES -->
+
+[#336]: https://github.com/dusk-network/piecrust/issues/336
 [#325]: https://github.com/dusk-network/piecrust/issues/325
 [#324]: https://github.com/dusk-network/piecrust/issues/324
 [#316]: https://github.com/dusk-network/piecrust/issues/316
@@ -400,6 +405,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#93]: https://github.com/dusk-network/piecrust/issues/93
 
 <!-- VERSIONS -->
+
 [Unreleased]: https://github.com/dusk-network/piecrust/compare/piecrust-0.16.0...HEAD
 [0.16.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.15.0...piecrust-0.16.0
 [0.15.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.14.1...piecrust-0.15.0

--- a/piecrust/src/contract.rs
+++ b/piecrust/src/contract.rs
@@ -13,43 +13,41 @@ use rkyv::{Archive, Deserialize, Serialize};
 
 use crate::error::Error;
 
-pub struct ContractData<'a, A, const N: usize> {
+pub struct ContractData<'a, A> {
     pub(crate) contract_id: Option<ContractId>,
     pub(crate) constructor_arg: Option<&'a A>,
-    pub(crate) owner: [u8; N],
+    pub(crate) owner: Vec<u8>,
 }
 
 // `()` is done on purpose, since by default it should be that the constructor
 // takes no argument.
-impl<'a, const N: usize> ContractData<'a, (), N> {
+impl<'a> ContractData<'a, ()> {
     /// Build a deploy data structure.
     ///
     /// This function returns a builder that can be used to set optional fields
     /// in contract deployment.
-    pub fn builder(owner: [u8; N]) -> ContractDataBuilder<'a, (), N> {
+    pub fn builder(owner: impl Into<Vec<u8>>) -> ContractDataBuilder<'a, ()> {
         ContractDataBuilder {
             contract_id: None,
             constructor_arg: None,
-            owner,
+            owner: owner.into(),
         }
     }
 }
 
-impl<'a, A, const N: usize> From<ContractDataBuilder<'a, A, N>>
-    for ContractData<'a, A, N>
-{
-    fn from(builder: ContractDataBuilder<'a, A, N>) -> Self {
+impl<'a, A> From<ContractDataBuilder<'a, A>> for ContractData<'a, A> {
+    fn from(builder: ContractDataBuilder<'a, A>) -> Self {
         builder.build()
     }
 }
 
-pub struct ContractDataBuilder<'a, A, const N: usize> {
+pub struct ContractDataBuilder<'a, A> {
     contract_id: Option<ContractId>,
-    owner: [u8; N],
+    owner: Vec<u8>,
     constructor_arg: Option<&'a A>,
 }
 
-impl<'a, A, const N: usize> ContractDataBuilder<'a, A, N> {
+impl<'a, A> ContractDataBuilder<'a, A> {
     /// Set the deployment contract ID.
     pub fn contract_id(mut self, id: ContractId) -> Self {
         self.contract_id = Some(id);
@@ -57,7 +55,7 @@ impl<'a, A, const N: usize> ContractDataBuilder<'a, A, N> {
     }
 
     /// Set the constructor argument for deployment.
-    pub fn constructor_arg<B>(self, arg: &B) -> ContractDataBuilder<B, N> {
+    pub fn constructor_arg<B>(self, arg: &B) -> ContractDataBuilder<B> {
         ContractDataBuilder {
             contract_id: self.contract_id,
             owner: self.owner,
@@ -65,7 +63,7 @@ impl<'a, A, const N: usize> ContractDataBuilder<'a, A, N> {
         }
     }
 
-    pub fn build(self) -> ContractData<'a, A, N> {
+    pub fn build(self) -> ContractData<'a, A> {
         ContractData {
             contract_id: self.contract_id,
             constructor_arg: self.constructor_arg,

--- a/piecrust/src/contract.rs
+++ b/piecrust/src/contract.rs
@@ -16,7 +16,7 @@ use crate::error::Error;
 pub struct ContractData<'a, A> {
     pub(crate) contract_id: Option<ContractId>,
     pub(crate) constructor_arg: Option<&'a A>,
-    pub(crate) owner: Vec<u8>,
+    pub(crate) owner: Option<Vec<u8>>,
 }
 
 // `()` is done on purpose, since by default it should be that the constructor
@@ -26,11 +26,11 @@ impl<'a> ContractData<'a, ()> {
     ///
     /// This function returns a builder that can be used to set optional fields
     /// in contract deployment.
-    pub fn builder(owner: impl Into<Vec<u8>>) -> ContractDataBuilder<'a, ()> {
+    pub fn builder() -> ContractDataBuilder<'a, ()> {
         ContractDataBuilder {
             contract_id: None,
             constructor_arg: None,
-            owner: owner.into(),
+            owner: None,
         }
     }
 }
@@ -43,7 +43,7 @@ impl<'a, A> From<ContractDataBuilder<'a, A>> for ContractData<'a, A> {
 
 pub struct ContractDataBuilder<'a, A> {
     contract_id: Option<ContractId>,
-    owner: Vec<u8>,
+    owner: Option<Vec<u8>>,
     constructor_arg: Option<&'a A>,
 }
 
@@ -61,6 +61,12 @@ impl<'a, A> ContractDataBuilder<'a, A> {
             owner: self.owner,
             constructor_arg: Some(arg),
         }
+    }
+
+    /// Set the owner of the contract.
+    pub fn owner(mut self, owner: impl Into<Vec<u8>>) -> Self {
+        self.owner = Some(owner.into());
+        self
     }
 
     pub fn build(self) -> ContractData<'a, A> {

--- a/piecrust/src/lib.rs
+++ b/piecrust/src/lib.rs
@@ -89,7 +89,13 @@
 //! const LIMIT: u64 = 1_000_000;
 //!
 //! let mut session = vm.session(SessionData::builder()).unwrap();
-//! let counter_id = session.deploy(contract_bytecode!("counter"), ContractData::builder(OWNER), LIMIT).unwrap();
+//! let counter_id = session
+//!     .deploy(
+//!         contract_bytecode!("counter"),
+//!         ContractData::builder().owner(OWNER),
+//!         LIMIT,
+//!     )
+//!     .unwrap();
 //!
 //! assert_eq!(session.call::<_, i64>(counter_id, "read_value", &(), LIMIT).unwrap().data, 0xfc);
 //! session.call::<_, ()>(counter_id, "increment", &(), LIMIT).unwrap();

--- a/piecrust/src/session.rs
+++ b/piecrust/src/session.rs
@@ -34,6 +34,7 @@ const MAX_META_SIZE: usize = ARGBUF_LEN;
 pub const INIT_METHOD: &str = "init";
 
 unsafe impl Send for Session {}
+
 unsafe impl Sync for Session {}
 
 /// A running mutation to a state.
@@ -208,7 +209,7 @@ impl Session {
     ///
     /// [`ContractId`]: ContractId
     /// [`PersistenceError`]: PersistenceError
-    pub fn deploy<'a, A, D, const N: usize>(
+    pub fn deploy<'a, A, D>(
         &mut self,
         bytecode: &[u8],
         deploy_data: D,
@@ -216,7 +217,7 @@ impl Session {
     ) -> Result<ContractId, Error>
     where
         A: 'a + for<'b> Serialize<StandardBufSerializer<'b>>,
-        D: Into<ContractData<'a, A, N>>,
+        D: Into<ContractData<'a, A>>,
     {
         let mut deploy_data = deploy_data.into();
 
@@ -404,7 +405,7 @@ impl Session {
     /// The migration may error during execution for a myriad of reasons. The
     /// caller is encouraged to drop the `Session` should an error occur as it
     /// will more than likely be left in an inconsistent state.
-    pub fn migrate<'a, A, D, F, const N: usize>(
+    pub fn migrate<'a, A, D, F>(
         mut self,
         contract: ContractId,
         bytecode: &[u8],
@@ -414,7 +415,7 @@ impl Session {
     ) -> Result<Self, Error>
     where
         A: 'a + for<'b> Serialize<StandardBufSerializer<'b>>,
-        D: Into<ContractData<'a, A, N>>,
+        D: Into<ContractData<'a, A>>,
         F: FnOnce(ContractId, &mut Session) -> Result<(), Error>,
     {
         let new_contract =

--- a/piecrust/src/session.rs
+++ b/piecrust/src/session.rs
@@ -209,6 +209,9 @@ impl Session {
     ///
     /// [`ContractId`]: ContractId
     /// [`PersistenceError`]: PersistenceError
+    ///
+    /// # Panics
+    /// If `deploy_data` does not specify an owner, this will panic.
     pub fn deploy<'a, A, D>(
         &mut self,
         bytecode: &[u8],
@@ -248,7 +251,9 @@ impl Session {
             contract_id,
             bytecode,
             constructor_arg,
-            deploy_data.owner.to_vec(),
+            deploy_data
+                .owner
+                .expect("Owner must be specified when deploying a contract"),
             gas_limit,
         )?;
 

--- a/piecrust/tests/box.rs
+++ b/piecrust/tests/box.rs
@@ -18,7 +18,7 @@ pub fn box_set_get() -> Result<(), Error> {
 
     let id = session.deploy(
         contract_bytecode!("box"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 
@@ -43,7 +43,7 @@ pub fn box_set_get_raw() -> Result<(), Error> {
 
     let id = session.deploy(
         contract_bytecode!("box"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 

--- a/piecrust/tests/callcenter.rs
+++ b/piecrust/tests/callcenter.rs
@@ -18,7 +18,7 @@ pub fn cc_read_counter() -> Result<(), Error> {
 
     let counter_id = session.deploy(
         contract_bytecode!("counter"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 
@@ -29,7 +29,7 @@ pub fn cc_read_counter() -> Result<(), Error> {
 
     let center_id = session.deploy(
         contract_bytecode!("callcenter"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 
@@ -50,7 +50,7 @@ pub fn cc_direct() -> Result<(), Error> {
 
     let counter_id = session.deploy(
         contract_bytecode!("counter"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 
@@ -60,7 +60,7 @@ pub fn cc_direct() -> Result<(), Error> {
 
     let center_id = session.deploy(
         contract_bytecode!("callcenter"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 
@@ -99,7 +99,7 @@ pub fn cc_passthrough() -> Result<(), Error> {
 
     let center_id = session.deploy(
         contract_bytecode!("callcenter"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 
@@ -122,12 +122,12 @@ pub fn cc_delegated_read() -> Result<(), Error> {
 
     let counter_id = session.deploy(
         contract_bytecode!("counter"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
     let center_id = session.deploy(
         contract_bytecode!("callcenter"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 
@@ -159,12 +159,12 @@ pub fn cc_delegated_write() -> Result<(), Error> {
     let mut session = vm.session(SessionData::builder())?;
     let counter_id = session.deploy(
         contract_bytecode!("counter"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
     let center_id = session.deploy(
         contract_bytecode!("callcenter"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 
@@ -190,7 +190,7 @@ pub fn cc_self() -> Result<(), Error> {
 
     let center_id = session.deploy(
         contract_bytecode!("callcenter"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 
@@ -211,7 +211,7 @@ pub fn cc_caller() -> Result<(), Error> {
 
     let center_id = session.deploy(
         contract_bytecode!("callcenter"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 
@@ -231,7 +231,7 @@ pub fn cc_caller_uninit() -> Result<(), Error> {
 
     let center_id = session.deploy(
         contract_bytecode!("callcenter"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 
@@ -250,7 +250,7 @@ pub fn cc_self_id() -> Result<(), Error> {
 
     let center_id = session.deploy(
         contract_bytecode!("callcenter"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 

--- a/piecrust/tests/cold-reboot/src/main.rs
+++ b/piecrust/tests/cold-reboot/src/main.rs
@@ -10,6 +10,7 @@ use std::path::{Path, PathBuf};
 use std::{env, fs};
 
 use piecrust::{ContractData, ContractId, SessionData, VM};
+
 const COUNTER_ID: ContractId = {
     let mut bytes = [0u8; 32];
     bytes[0] = 99;
@@ -28,7 +29,7 @@ fn initialize_counter<P: AsRef<Path>>(
 
     session.deploy(
         counter_bytecode,
-        ContractData::builder(OWNER).contract_id(COUNTER_ID),
+        ContractData::builder().owner(OWNER).contract_id(COUNTER_ID),
         u64::MAX,
     )?;
     session.call::<_, ()>(COUNTER_ID, "increment", &(), u64::MAX)?;

--- a/piecrust/tests/commit.rs
+++ b/piecrust/tests/commit.rs
@@ -21,7 +21,7 @@ fn read_write_session() -> Result<(), Error> {
         let mut session = vm.session(SessionData::builder())?;
         let id = session.deploy(
             contract_bytecode!("counter"),
-            ContractData::builder(OWNER),
+            ContractData::builder().owner(OWNER),
             LIMIT,
         )?;
 
@@ -44,7 +44,7 @@ fn read_write_session() -> Result<(), Error> {
     let mut other_session = vm.session(SessionData::builder())?;
     let id = other_session.deploy(
         contract_bytecode!("counter"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 
@@ -76,7 +76,7 @@ fn commit_restore() -> Result<(), Error> {
     let mut session_1 = vm.session(SessionData::builder())?;
     let id = session_1.deploy(
         contract_bytecode!("counter"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
     // commit 1
@@ -125,12 +125,12 @@ fn commit_restore_two_contracts_session() -> Result<(), Error> {
     let mut session = vm.session(SessionData::builder())?;
     let id_1 = session.deploy(
         contract_bytecode!("counter"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
     let id_2 = session.deploy(
         contract_bytecode!("box"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 
@@ -190,7 +190,7 @@ fn multiple_commits() -> Result<(), Error> {
     let mut session = vm.session(SessionData::builder())?;
     let id = session.deploy(
         contract_bytecode!("counter"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
     // commit 1
@@ -240,12 +240,12 @@ fn root_equal_on_err() -> Result<(), Error> {
 
     let callcenter_id = session.deploy(
         contract_bytecode!("callcenter"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
     let counter_id = session.deploy(
         contract_bytecode!("counter"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 
@@ -311,7 +311,7 @@ fn concurrent_sessions() -> Result<(), Error> {
     let mut session = vm.session(SessionData::builder())?;
     let counter = session.deploy(
         contract_bytecode!("counter"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 
@@ -405,7 +405,7 @@ fn make_session(vm: &VM) -> Result<(Session, ContractId), Error> {
         vm.session(SessionData::builder().insert("height", HEIGHT)?)?;
     let contract_id = session.deploy(
         contract_bytecode!("everest"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
     Ok((session, contract_id))

--- a/piecrust/tests/constructor.rs
+++ b/piecrust/tests/constructor.rs
@@ -18,7 +18,9 @@ fn constructor() -> Result<(), Error> {
 
     let id = session.deploy(
         contract_bytecode!("constructor"),
-        ContractData::builder(OWNER).constructor_arg(&0xabu8),
+        ContractData::builder()
+            .owner(OWNER)
+            .constructor_arg(&0xabu8),
         LIMIT,
     )?;
 
@@ -80,7 +82,7 @@ fn empty_constructor_argument() -> Result<(), Error> {
 
     let id = session.deploy(
         contract_bytecode!("empty_constructor"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 

--- a/piecrust/tests/counter.rs
+++ b/piecrust/tests/counter.rs
@@ -17,7 +17,7 @@ fn counter_read_simple() -> Result<(), Error> {
 
     let id = session.deploy(
         contract_bytecode!("counter"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 
@@ -37,7 +37,7 @@ fn counter_read_write_simple() -> Result<(), Error> {
 
     let id = session.deploy(
         contract_bytecode!("counter"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 
@@ -64,12 +64,12 @@ fn call_through_c() -> Result<(), Error> {
 
     let counter_id = session.deploy(
         contract_bytecode!("counter"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
     let c_example_id = session.deploy(
         contract_bytecode!("c_example"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 
@@ -79,7 +79,7 @@ fn call_through_c() -> Result<(), Error> {
                 c_example_id,
                 "increment_and_read",
                 &counter_id,
-                LIMIT
+                LIMIT,
             )?
             .data,
         0xfd
@@ -96,7 +96,7 @@ fn increment_panic() -> Result<(), Error> {
 
     let counter_id = session.deploy(
         contract_bytecode!("fallible_counter"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 

--- a/piecrust/tests/crossover.rs
+++ b/piecrust/tests/crossover.rs
@@ -30,12 +30,16 @@ fn crossover() -> Result<(), Error> {
 
     session.deploy(
         contract_bytecode!("crossover"),
-        ContractData::builder(OWNER).contract_id(CROSSOVER_ONE),
+        ContractData::builder()
+            .owner(OWNER)
+            .contract_id(CROSSOVER_ONE),
         LIMIT,
     )?;
     session.deploy(
         contract_bytecode!("crossover"),
-        ContractData::builder(OWNER).contract_id(CROSSOVER_TWO),
+        ContractData::builder()
+            .owner(OWNER)
+            .contract_id(CROSSOVER_TWO),
         LIMIT,
     )?;
 

--- a/piecrust/tests/debugger.rs
+++ b/piecrust/tests/debugger.rs
@@ -17,7 +17,7 @@ pub fn debug() -> Result<(), Error> {
 
     let id = session.deploy(
         contract_bytecode!("debugger"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 

--- a/piecrust/tests/deploy_with_id.rs
+++ b/piecrust/tests/deploy_with_id.rs
@@ -20,7 +20,9 @@ pub fn deploy_with_id() -> Result<(), Error> {
     let mut session = vm.session(SessionData::builder())?;
     session.deploy(
         bytecode,
-        ContractData::builder(OWNER).contract_id(contract_id),
+        ContractData::builder()
+            .owner(OWNER)
+            .contract_id(contract_id),
         LIMIT,
     )?;
 

--- a/piecrust/tests/eventer.rs
+++ b/piecrust/tests/eventer.rs
@@ -17,7 +17,7 @@ pub fn vm_center_events() -> Result<(), Error> {
 
     let eventer_id = session.deploy(
         contract_bytecode!("eventer"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 

--- a/piecrust/tests/everest.rs
+++ b/piecrust/tests/everest.rs
@@ -19,7 +19,7 @@ pub fn height() -> Result<(), Error> {
 
     let id = session.deploy(
         contract_bytecode!("everest"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 
@@ -35,7 +35,7 @@ pub fn meta_data_optionality() -> Result<(), Error> {
     let mut session = vm.session(SessionData::builder())?;
     let id = session.deploy(
         contract_bytecode!("everest"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
     let height: Option<u64> = session.call(id, "get_height", &(), LIMIT)?.data;

--- a/piecrust/tests/feeder.rs
+++ b/piecrust/tests/feeder.rs
@@ -19,7 +19,7 @@ fn feed() -> Result<(), Error> {
 
     let id = session.deploy(
         contract_bytecode!("feeder"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 
@@ -57,7 +57,7 @@ fn feed_errors_when_normal_call() -> Result<(), Error> {
 
     let id = session.deploy(
         contract_bytecode!("feeder"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 

--- a/piecrust/tests/fibonacci.rs
+++ b/piecrust/tests/fibonacci.rs
@@ -17,7 +17,7 @@ pub fn fibo() -> Result<(), Error> {
 
     let id = session.deploy(
         contract_bytecode!("fibonacci"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 

--- a/piecrust/tests/growth.rs
+++ b/piecrust/tests/growth.rs
@@ -18,7 +18,7 @@ fn grow_a_bunch() -> Result<(), Error> {
 
     let id = session.deploy(
         contract_bytecode!("grower"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 
@@ -61,12 +61,12 @@ fn error_reverts_growth() -> Result<(), Error> {
 
     let id = session.deploy(
         contract_bytecode!("grower"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
     let _ = session_err.deploy(
         contract_bytecode!("grower"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 

--- a/piecrust/tests/host.rs
+++ b/piecrust/tests/host.rs
@@ -73,7 +73,7 @@ pub fn host_hash() -> Result<(), Error> {
 
     let id = session.deploy(
         contract_bytecode!("host"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 
@@ -143,7 +143,7 @@ pub fn host_proof() -> Result<(), Error> {
 
     let id = session.deploy(
         contract_bytecode!("host"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 

--- a/piecrust/tests/merkle.rs
+++ b/piecrust/tests/merkle.rs
@@ -16,7 +16,7 @@ pub fn merkle_root() -> Result<(), Error> {
 
     let id = session.deploy(
         contract_bytecode!("merkle"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 

--- a/piecrust/tests/metadata.rs
+++ b/piecrust/tests/metadata.rs
@@ -19,7 +19,7 @@ fn metadata() -> Result<(), Error> {
 
     let id = session.deploy(
         contract_bytecode!("metadata"),
-        ContractData::builder(EXPECTED_OWNER),
+        ContractData::builder().owner(EXPECTED_OWNER),
         LIMIT,
     )?;
 
@@ -63,12 +63,16 @@ fn owner_of() -> Result<(), Error> {
 
     session.deploy(
         contract_bytecode!("metadata"),
-        ContractData::builder(EXPECTED_OWNER_0).contract_id(CONTRACT_ID_0),
+        ContractData::builder()
+            .owner(EXPECTED_OWNER_0)
+            .contract_id(CONTRACT_ID_0),
         LIMIT,
     )?;
     session.deploy(
         contract_bytecode!("metadata"),
-        ContractData::builder(EXPECTED_OWNER_1).contract_id(CONTRACT_ID_1),
+        ContractData::builder()
+            .owner(EXPECTED_OWNER_1)
+            .contract_id(CONTRACT_ID_1),
         LIMIT,
     )?;
 

--- a/piecrust/tests/persistence.rs
+++ b/piecrust/tests/persistence.rs
@@ -21,12 +21,12 @@ fn session_commits_persistence() -> Result<(), Error> {
         let mut session = vm.session(SessionData::builder())?;
         id_1 = session.deploy(
             contract_bytecode!("counter"),
-            ContractData::builder(OWNER),
+            ContractData::builder().owner(OWNER),
             LIMIT,
         )?;
         id_2 = session.deploy(
             contract_bytecode!("box"),
-            ContractData::builder(OWNER),
+            ContractData::builder().owner(OWNER),
             LIMIT,
         )?;
 
@@ -106,12 +106,12 @@ fn contracts_persistence() -> Result<(), Error> {
     let mut session = vm.session(SessionData::builder())?;
     let id_1 = session.deploy(
         contract_bytecode!("counter"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
     let id_2 = session.deploy(
         contract_bytecode!("box"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 
@@ -156,7 +156,7 @@ fn migration() -> Result<(), Error> {
 
     let contract = session.deploy(
         contract_bytecode!("counter"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 
@@ -170,7 +170,7 @@ fn migration() -> Result<(), Error> {
     session = session.migrate(
         contract,
         contract_bytecode!("double_counter"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
         |new_contract, session| {
             let old_counter_value = session

--- a/piecrust/tests/root.rs
+++ b/piecrust/tests/root.rs
@@ -17,7 +17,7 @@ pub fn state_root_calculation() -> Result<(), Error> {
     let mut session = vm.session(SessionData::builder())?;
     let id_1 = session.deploy(
         contract_bytecode!("counter"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 
@@ -34,7 +34,7 @@ pub fn state_root_calculation() -> Result<(), Error> {
     let mut session = vm.session(SessionData::builder().base(commit_1))?;
     let id_2 = session.deploy(
         contract_bytecode!("box"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
     session.call::<i16, ()>(id_2, "set", &0x11, LIMIT)?;
@@ -66,7 +66,7 @@ pub fn inclusion_proofs() -> Result<(), Error> {
 
     let counter_id = session.deploy(
         contract_bytecode!("counter"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 

--- a/piecrust/tests/spender.rs
+++ b/piecrust/tests/spender.rs
@@ -18,12 +18,12 @@ pub fn gas_get_used() -> Result<(), Error> {
 
     let counter_id = session.deploy(
         contract_bytecode!("counter"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
     let center_id = session.deploy(
         contract_bytecode!("callcenter"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 
@@ -52,12 +52,12 @@ pub fn panic_msg_gets_through() -> Result<(), Error> {
 
     let spender_id = session.deploy(
         contract_bytecode!("spender"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
     let callcenter_id = session.deploy(
         contract_bytecode!("callcenter"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 
@@ -83,7 +83,7 @@ pub fn fails_with_out_of_gas() -> Result<(), Error> {
 
     let counter_id = session.deploy(
         contract_bytecode!("counter"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 
@@ -105,23 +105,23 @@ pub fn contract_sets_call_limit() -> Result<(), Error> {
 
     session_1st.deploy(
         contract_bytecode!("spender"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
     session_1st.deploy(
         contract_bytecode!("callcenter"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 
     let spender_id = session_2nd.deploy(
         contract_bytecode!("spender"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
     let callcenter_id = session_2nd.deploy(
         contract_bytecode!("callcenter"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 
@@ -159,7 +159,7 @@ pub fn limit_and_spent() -> Result<(), Error> {
 
     let spender_id = session.deploy(
         contract_bytecode!("spender"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 

--- a/piecrust/tests/stack.rs
+++ b/piecrust/tests/stack.rs
@@ -17,7 +17,7 @@ pub fn push_pop() -> Result<(), Error> {
 
     let id = session.deploy(
         contract_bytecode!("stack"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 
@@ -45,7 +45,7 @@ pub fn multi_push_pop() -> Result<(), Error> {
 
     let id = session.deploy(
         contract_bytecode!("stack"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 

--- a/piecrust/tests/validation.rs
+++ b/piecrust/tests/validation.rs
@@ -17,7 +17,7 @@ fn out_of_bounds() -> Result<(), Error> {
 
     let c_example_id = session.deploy(
         contract_bytecode!("c_example"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 
@@ -37,7 +37,7 @@ fn bad_contract() -> Result<(), Error> {
     let _ = session
         .deploy(
             contract_bytecode!("invalid"),
-            ContractData::builder(OWNER),
+            ContractData::builder().owner(OWNER),
             LIMIT,
         )
         .expect_err("Deploying an invalid contract should error");

--- a/piecrust/tests/vector.rs
+++ b/piecrust/tests/vector.rs
@@ -17,7 +17,7 @@ pub fn vector_push_pop() -> Result<(), Error> {
 
     let id = session.deploy(
         contract_bytecode!("vector"),
-        ContractData::builder(OWNER),
+        ContractData::builder().owner(OWNER),
         LIMIT,
     )?;
 


### PR DESCRIPTION
`Session::migrate` is changed to allow for taking the owner of the previous contract, as opposed to it being mandatory to set a new owner.

This entailed numerous API change, the gist of which being that the `owner` is handled internally as a `Vec<u8>` as opposed to a `[u8; N]`. This puts some responsibility on the user of the crate to think about what this means for when the contracts call `owner` or `self_owner`. It is likely wise to only set owner which are always the same size.

Resolves #336 