### PR TITLE
piecrust: bump version to '0.17.0'

### DIFF
--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0] - 2024-02-28
+
 ### Added
 
 - Add `ContractDataBuilder::owner` to allow for setting the owner of a contract
@@ -414,7 +416,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- VERSIONS -->
 
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/piecrust-0.16.0...HEAD
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/piecrust-0.17.0...HEAD
+[0.17.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.16.0...piecrust-0.17.0
 [0.16.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.15.0...piecrust-0.16.0
 [0.15.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.14.1...piecrust-0.15.0
 [0.14.1]: https://github.com/dusk-network/piecrust/compare/piecrust-0.14.0...piecrust-0.14.1

--- a/piecrust/Cargo.toml
+++ b/piecrust/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.17.0-rc.0"
+version = "0.17.0"
 
 edition = "2021"
 license = "MPL-2.0"


### PR DESCRIPTION
## [0.17.0] - 2024-02-28

### Added

- Add `ContractDataBuilder::owner` to allow for setting the owner of a contract
  on deploy time [#336]

### Changed

- Change `migrate` to take the owner of the contract being replaced if it is
  not set by the caller [#336]
- Make `owner` field optional in `ContractData` and `ContractDataBuilder` [#336]
- Change `ContractData` and `ContractDataBuilder` to take a `Vec<u8>` as owner
  instead of `[u8; N]` [#336]
- Use empty constructor arguments by default [#316]
- Upgrade `dusk-wasmtime` to version `18`