### PR TITLE
Release `0.18.0`

### DIFF
--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0] - 2024-03-27
+
 ### Added
 
 - Add `Error::ArgumentBufferOverflow` variant [#343]
@@ -438,7 +440,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- VERSIONS -->
 
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/piecrust-0.17.0...HEAD
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/piecrust-0.18.0...HEAD
+[0.18.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.17.0...piecrust-0.18.0
 [0.17.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.16.0...piecrust-0.17.0
 [0.16.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.15.0...piecrust-0.16.0
 [0.15.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.14.1...piecrust-0.15.0

--- a/piecrust/Cargo.toml
+++ b/piecrust/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.17.0"
+version = "0.18.0"
 
 edition = "2021"
 license = "MPL-2.0"


### PR DESCRIPTION
## [0.18.0] - 2024-03-27

### Added

- Add `Error::ArgumentBufferOverflow` variant [#343]

### Fixed

- Fix possible under/overflows reported by audit [#343]


### Changed

- Change `Session::feeder_call` and `Session::feeder_call_raw` to allow for the
  caller to specify the gas limit [#344]

### Fixed

- Fix `Session::migrate` to replace the contract ID in the new contract's
  metadata to the old contract's ID [#347]

[0.18.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.17.0...piecrust-0.18.0
