### PR TITLE
Upgrade to `dusk-wasmtime` version `19`

### DIFF
--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade `dusk-wasmtime` to version `19`
+
 ## [0.18.0] - 2024-03-27
 
 ### Added

--- a/piecrust/Cargo.toml
+++ b/piecrust/Cargo.toml
@@ -16,7 +16,7 @@ license = "MPL-2.0"
 crumbles = { version = "0.3", path = "../crumbles" }
 piecrust-uplink = { version = "0.11", path = "../piecrust-uplink" }
 
-dusk-wasmtime = { version = "18", default-features = false, features = ["cranelift", "runtime", "parallel-compilation"] }
+dusk-wasmtime = { version = "19", default-features = false, features = ["cranelift", "runtime", "parallel-compilation"] }
 bytecheck = "0.6"
 rkyv = { version = "0.7", features = ["size_32", "validation"] }
 blake3 = "1"

--- a/piecrust/src/instance.rs
+++ b/piecrust/src/instance.rs
@@ -130,7 +130,7 @@ impl WrappedInstance {
                     return Err(Error::InvalidFunction(func_name.to_string()));
                 }
                 let param = params.next().unwrap();
-                if param != ValType::I32 {
+                if !param.matches(&ValType::I32) {
                     return Err(Error::InvalidFunction(func_name.to_string()));
                 }
 
@@ -140,7 +140,7 @@ impl WrappedInstance {
                     return Err(Error::InvalidFunction(func_name.to_string()));
                 }
                 let result = results.next().unwrap();
-                if result != ValType::I32 {
+                if !result.matches(&ValType::I32) {
                     return Err(Error::InvalidFunction(func_name.to_string()));
                 }
             }


### PR DESCRIPTION
In this version, `wasmtime` introduces a preliminary version of the [`winch`] compiler, which is ready to use on `x86` embeddings. They advise not using it in production just yet, but at least its ready for testing.

[`winch`]: https://github.com/bytecodealliance/wasmtime/releases/tag/v19.0.0

See-also: https://github.com/dusk-network/piecrust/issues/351