### PR TITLE
`piecrust` release `0.18.1`

### DIFF
--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Upgrade `dusk-wasmtime` to version `19`
+- Upgrade `dusk-wasmtime` to version `20`
 
 ## [0.18.0] - 2024-03-27
 

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.1] - 2024-04-24
+
 ### Changed
 
 - Upgrade `dusk-wasmtime` to version `20`
@@ -444,7 +446,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- VERSIONS -->
 
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/piecrust-0.18.0...HEAD
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/piecrust-0.18.1...HEAD
+[0.18.1]: https://github.com/dusk-network/piecrust/compare/piecrust-0.18.0...piecrust-0.18.1
 [0.18.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.17.0...piecrust-0.18.0
 [0.17.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.16.0...piecrust-0.17.0
 [0.16.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.15.0...piecrust-0.16.0

--- a/piecrust/Cargo.toml
+++ b/piecrust/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.18.0"
+version = "0.18.1"
 
 edition = "2021"
 license = "MPL-2.0"

--- a/piecrust/Cargo.toml
+++ b/piecrust/Cargo.toml
@@ -16,7 +16,7 @@ license = "MPL-2.0"
 crumbles = { version = "0.3", path = "../crumbles" }
 piecrust-uplink = { version = "0.11", path = "../piecrust-uplink" }
 
-dusk-wasmtime = { version = "19", default-features = false, features = ["cranelift", "runtime", "parallel-compilation"] }
+dusk-wasmtime = { version = "20", default-features = false, features = ["cranelift", "runtime", "parallel-compilation"] }
 bytecheck = "0.6"
 rkyv = { version = "0.7", features = ["size_32", "validation"] }
 blake3 = "1"


### PR DESCRIPTION
## [piecrust 0.18.1] - 2024-04-24

### Changed

- Upgrade `dusk-wasmtime` to version `20`

[piecrust 0.18.1]: https://github.com/dusk-network/piecrust/compare/piecrust-0.18.0...piecrust-0.18.1