### PR TITLE
Make storage instructions cost

### DIFF
--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 
+- Make storage instructions cost 4 gas per byte [#359]
 - Upgrade `dusk-wasmtime` to version `21.0.0-alpha` [#359]
 
 ## [0.19.0] - 2024-05-08

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+
+- Upgrade `dusk-wasmtime` to version `21.0.0-alpha` [#359]
+
 ## [0.19.0] - 2024-05-08
 
 ### Added
@@ -413,6 +417,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- ISSUES -->
 
+[#359]: https://github.com/dusk-network/piecrust/issues/359
 [#353]: https://github.com/dusk-network/piecrust/issues/353
 [#350]: https://github.com/dusk-network/piecrust/issues/350
 [#347]: https://github.com/dusk-network/piecrust/issues/347

--- a/piecrust/Cargo.toml
+++ b/piecrust/Cargo.toml
@@ -16,7 +16,7 @@ license = "MPL-2.0"
 crumbles = { version = "0.3", path = "../crumbles" }
 piecrust-uplink = { version = "0.12", path = "../piecrust-uplink" }
 
-dusk-wasmtime = { version = "20", default-features = false, features = ["cranelift", "runtime", "parallel-compilation"] }
+dusk-wasmtime = { version = "21.0.0-alpha", default-features = false, features = ["cranelift", "runtime", "parallel-compilation"] }
 bytecheck = "0.6"
 rkyv = { version = "0.7", features = ["size_32", "validation"] }
 blake3 = "1"

--- a/piecrust/src/vm.rs
+++ b/piecrust/src/vm.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use std::thread;
 
 use dusk_wasmtime::{
-    Config, Engine, ModuleVersionStrategy, OptLevel, Strategy,
+    Config, Engine, ModuleVersionStrategy, OperatorCost, OptLevel, Strategy,
     WasmBacktraceDetails,
 };
 use tempfile::tempdir;
@@ -56,6 +56,39 @@ fn config() -> Config {
 
     // Support 64-bit memories
     config.wasm_memory64(true);
+
+    const BYTE_STORE_COST: i64 = 4;
+    const BYTE4_STORE_COST: i64 = 4 * BYTE_STORE_COST;
+    const BYTE8_STORE_COST: i64 = 8 * BYTE_STORE_COST;
+    const BYTE16_STORE_COST: i64 = 16 * BYTE_STORE_COST;
+
+    config.operator_cost(OperatorCost {
+        I32Store: BYTE4_STORE_COST,
+        F32Store: BYTE4_STORE_COST,
+        I32Store8: BYTE4_STORE_COST,
+        I32Store16: BYTE4_STORE_COST,
+        I32AtomicStore: BYTE4_STORE_COST,
+        I32AtomicStore8: BYTE4_STORE_COST,
+        I32AtomicStore16: BYTE4_STORE_COST,
+
+        I64Store: BYTE8_STORE_COST,
+        F64Store: BYTE8_STORE_COST,
+        I64Store8: BYTE8_STORE_COST,
+        I64Store16: BYTE8_STORE_COST,
+        I64Store32: BYTE8_STORE_COST,
+        I64AtomicStore: BYTE8_STORE_COST,
+        I64AtomicStore8: BYTE8_STORE_COST,
+        I64AtomicStore16: BYTE8_STORE_COST,
+        I64AtomicStore32: BYTE8_STORE_COST,
+
+        V128Store: BYTE16_STORE_COST,
+        V128Store8Lane: BYTE16_STORE_COST,
+        V128Store16Lane: BYTE16_STORE_COST,
+        V128Store32Lane: BYTE16_STORE_COST,
+        V128Store64Lane: BYTE16_STORE_COST,
+
+        ..Default::default()
+    });
 
     config
 }

--- a/piecrust/tests/spender.rs
+++ b/piecrust/tests/spender.rs
@@ -64,7 +64,7 @@ pub fn panic_msg_gets_through() -> Result<(), Error> {
     let receipt = session.call::<_, Result<(), ContractError>>(
         callcenter_id,
         "call_spend_with_limit",
-        &(spender_id, 1175u64),
+        &(spender_id, 4845u64),
         LIMIT,
     )?;
 


### PR DESCRIPTION
Each byte stored in the WebAssembly linear memory of a contract is made to cost 4 units of fuel - in the units that wasmtime uses. This makes storing a single byte as expensive as, for example, multiplying or subtracting two numbers.

The `MemoryGrow` instruction is purposefully left with the default price - just like any other instruction, due the fact that expanding the size of the linear memory doesn't actually cost a lot of resources, owing to the fact that a page that is never written to is never written to disk.

A single contract's compiled bytecode will contain a header, encoding within it information about the cost per WebAssembly instruction. If these don't match the costs configured for the current `VM` instantiation, the contract will be recompiled, just as what happens if the native instruction set doesn't match.

See-also: https://github.com/dusk-network/piecrust/issues/359