### PR TITLE
Release `piecrust@0.20.0`

### DIFF
--- a/piecrust-uplink/CHANGELOG.md
+++ b/piecrust-uplink/CHANGELOG.md
@@ -7,11 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.12.0] - 2024-05-08
+## [0.13.0] - 2024-06-05
 
 ### Added
 
 - Add support for metadata elements: free limit and free price hint [#357]
+
+## [0.12.0] - 2024-05-08
+
+### Added
+
 - Add contract charge setting method [#353] 
 - Add contract allowance setting method and a corresponding passing mechanism [#350] 
 
@@ -193,7 +198,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#136]: https://github.com/dusk-network/piecrust/issues/136
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/uplink-0.12.0...HEAD
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/uplink-0.13.0...HEAD
+[0.13.0]: https://github.com/dusk-network/piecrust/compare/uplink-0.12.0...uplink-0.13.0
 [0.12.0]: https://github.com/dusk-network/piecrust/compare/uplink-0.11.0...uplink-0.12.0
 [0.11.0]: https://github.com/dusk-network/piecrust/compare/uplink-0.10.0...uplink-0.11.0
 [0.10.0]: https://github.com/dusk-network/piecrust/compare/uplink-0.9.0...uplink-0.10.0

--- a/piecrust-uplink/Cargo.toml
+++ b/piecrust-uplink/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.12.0"
+version = "0.13.0"
 
 edition = "2021"
 license = "MPL-2.0"

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0] - 2024-06-05
+
 ## Added
 
 - Apply charging mechanism for host queries [#359]
@@ -469,7 +471,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- VERSIONS -->
 
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/piecrust-0.19.0...HEAD
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/piecrust-0.20.0...HEAD
+[0.20.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.19.0...piecrust-0.20.0
 [0.19.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.18.1...piecrust-0.19.0
 [0.18.1]: https://github.com/dusk-network/piecrust/compare/piecrust-0.18.0...piecrust-0.18.1
 [0.18.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.17.0...piecrust-0.18.0

--- a/piecrust/Cargo.toml
+++ b/piecrust/Cargo.toml
@@ -7,14 +7,14 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.19.0"
+version = "0.20.0"
 
 edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
 crumbles = { version = "0.3", path = "../crumbles" }
-piecrust-uplink = { version = "0.12", path = "../piecrust-uplink" }
+piecrust-uplink = { version = "0.13", path = "../piecrust-uplink" }
 
 dusk-wasmtime = { version = "21.0.0-alpha", default-features = false, features = ["cranelift", "runtime", "parallel-compilation"] }
 bytecheck = "0.6"


### PR DESCRIPTION
## [piecrust 0.20.0] - 2024-06-05

## Added

- Apply charging mechanism for host queries [#359]
- Add `HostQuery::execute` and `HostQuery::deserialize_and_price` [#359]
- Add support for metadata elements: free limit and free price hint [#357]

## Changed

- Drop `Fn(&mut [u8], u32) -> u32` bound for `HostQuery` [#359]
- Make storage instructions cost 4 gas per byte [#359]
- Upgrade `dusk-wasmtime` to version `21.0.0-alpha` [#359]

## [uplink 0.13.0] - 2024-06-05

### Added

- Add support for metadata elements: free limit and free price hint [#357]

[piecrust 0.20.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.19.0...piecrust-0.20.0
[uplink 0.13.0]: https://github.com/dusk-network/piecrust/compare/uplink-0.12.0...uplink-0.13.0
