### PR TITLE
`piecrust` release `0.21.0`

### DIFF
--- a/piecrust-uplink/CHANGELOG.md
+++ b/piecrust-uplink/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2024-06-26
+
 ### Removed
 
 - Remove all economic protocol-related functionality
@@ -204,7 +206,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#136]: https://github.com/dusk-network/piecrust/issues/136
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/uplink-0.13.0...HEAD
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/uplink-0.14.0...HEAD
+[0.14.0]: https://github.com/dusk-network/piecrust/compare/uplink-0.13.0...uplink-0.14.0
 [0.13.0]: https://github.com/dusk-network/piecrust/compare/uplink-0.12.0...uplink-0.13.0
 [0.12.0]: https://github.com/dusk-network/piecrust/compare/uplink-0.11.0...uplink-0.12.0
 [0.11.0]: https://github.com/dusk-network/piecrust/compare/uplink-0.10.0...uplink-0.11.0

--- a/piecrust-uplink/Cargo.toml
+++ b/piecrust-uplink/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.13.0"
+version = "0.14.0"
 
 edition = "2021"
 license = "MPL-2.0"

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0] - 2024-06-26
+
 ### Removed
 
 - Remove economic protocol-related functionality
@@ -475,7 +477,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- VERSIONS -->
 
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/piecrust-0.20.0...HEAD
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/piecrust-0.21.0...HEAD
+[0.21.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.20.0...piecrust-0.21.0
 [0.20.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.19.0...piecrust-0.20.0
 [0.19.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.18.1...piecrust-0.19.0
 [0.18.1]: https://github.com/dusk-network/piecrust/compare/piecrust-0.18.0...piecrust-0.18.1

--- a/piecrust/Cargo.toml
+++ b/piecrust/Cargo.toml
@@ -7,14 +7,14 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.20.0"
+version = "0.21.0"
 
 edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
 crumbles = { version = "0.3", path = "../crumbles" }
-piecrust-uplink = { version = "0.13", path = "../piecrust-uplink" }
+piecrust-uplink = { version = "0.14", path = "../piecrust-uplink" }
 
 dusk-wasmtime = { version = "21.0.0-alpha", default-features = false, features = ["cranelift", "runtime", "parallel-compilation"] }
 bytecheck = "0.6"


### PR DESCRIPTION
## [piecrust 0.21.0] - 2024-06-26

### Removed

- Remove economic protocol-related functionality

## [uplink 0.14.0] - 2024-06-26

### Removed

- Remove all economic protocol-related functionality
- Removed the 'charge' portion of the economic protocol [#365]

[uplink 0.14.0]: https://github.com/dusk-network/piecrust/compare/uplink-0.13.0...uplink-0.14.0
[piecrust 0.21.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.20.0...piecrust-0.21.0