### PR TITLE
Price event bytes at the same rate as storage

### DIFF
--- a/contracts/eventer/src/lib.rs
+++ b/contracts/eventer/src/lib.rs
@@ -8,6 +8,9 @@
 
 #![no_std]
 
+extern crate alloc;
+use alloc::vec::Vec;
+
 use piecrust_uplink as uplink;
 
 /// Struct that describes the state of the eventer contract
@@ -23,10 +26,23 @@ impl Eventer {
             uplink::emit("number", i);
         }
     }
+
+    pub fn emit_input(&mut self, input: Vec<u8>) -> (u64, u64) {
+        let spent_before = uplink::spent();
+        uplink::emit("input", input);
+        let spent_after = uplink::spent();
+        (spent_before, spent_after)
+    }
 }
 
 /// Expose `Eventer::emit_num()` to the host
 #[no_mangle]
 unsafe fn emit_events(arg_len: u32) -> u32 {
     uplink::wrap_call(arg_len, |num| STATE.emit_num(num))
+}
+
+/// Expose `Eventer::emit_input()` to the host
+#[no_mangle]
+unsafe fn emit_input(arg_len: u32) -> u32 {
+    uplink::wrap_call(arg_len, |input| STATE.emit_input(input))
 }

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Make each event byte cost the same as a storage byte [#359]
+
 ### Fixed
 
 - Fix incomplete removal of economic protocol functionality

--- a/piecrust/src/config.rs
+++ b/piecrust/src/config.rs
@@ -1,0 +1,8 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+// The gas cost for each byte
+pub const BYTE_STORE_COST: i64 = 4;

--- a/piecrust/src/lib.rs
+++ b/piecrust/src/lib.rs
@@ -118,6 +118,7 @@
 #[macro_use]
 mod bytecode_macro;
 mod call_tree;
+mod config;
 mod contract;
 mod error;
 mod imports;

--- a/piecrust/src/vm.rs
+++ b/piecrust/src/vm.rs
@@ -18,6 +18,7 @@ use dusk_wasmtime::{
 };
 use tempfile::tempdir;
 
+use crate::config::BYTE_STORE_COST;
 use crate::session::{Session, SessionData};
 use crate::store::ContractStore;
 use crate::Error::{self, PersistenceError};
@@ -58,7 +59,6 @@ fn config() -> Config {
     // Support 64-bit memories
     config.wasm_memory64(true);
 
-    const BYTE_STORE_COST: i64 = 4;
     const BYTE4_STORE_COST: i64 = 4 * BYTE_STORE_COST;
     const BYTE8_STORE_COST: i64 = 8 * BYTE_STORE_COST;
     const BYTE16_STORE_COST: i64 = 16 * BYTE_STORE_COST;


### PR DESCRIPTION
This PR introduces a cost to event emission proportional to the amount of bytes emitted, and at the same rate as a storage instruction. The rationale is that, while nodes are not necessarily required by protocol to hold this data like normal storage, it is still crucial data to hold for external applications, and contracts should be discouraged from emitting events that are "too large".

Hence, a payment at the same rate of storage seems appropriate for now. We may always choose to fine-tune this in a future protocol upgrade.

This should be the final round of pricing PRs, as I can't see the sense in pricing any other WebAssembly import offered to the contracts.

Resolves #359 
