### PR TITLE
uplink: add `impl PartialEq<[u8; 32]> for ContractId`

### DIFF
--- a/piecrust-uplink/CHANGELOG.md
+++ b/piecrust-uplink/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `impl PartialEq<[u8; 32]> for ContractId` [#375]
+
 ## [0.15.0] - 2024-07-03
 
 ### Fixed
@@ -188,6 +192,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - First `piecrust-uplink` release
 
 <!-- ISSUES -->
+[#375]: https://github.com/dusk-network/piecrust/issues/375
 [#365]: https://github.com/dusk-network/piecrust/issues/365
 [#357]: https://github.com/dusk-network/piecrust/issues/357
 [#353]: https://github.com/dusk-network/piecrust/issues/353

--- a/piecrust-uplink/src/types.rs
+++ b/piecrust-uplink/src/types.rs
@@ -117,6 +117,12 @@ impl AsMut<[u8]> for ContractId {
     }
 }
 
+impl PartialEq<[u8; CONTRACT_ID_BYTES]> for ContractId {
+    fn eq(&self, other: &[u8; CONTRACT_ID_BYTES]) -> bool {
+        self.0.eq(other)
+    }
+}
+
 impl core::fmt::Debug for ContractId {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         core::fmt::Display::fmt(self, f)


### PR DESCRIPTION
According to the [cross crate considerations](https://doc.rust-lang.org/std/cmp/trait.PartialEq.html#cross-crate-considerations) of the Rust documentation, one should only implement `PartialEq` for local types, and not for foreign types.

As for implementing it on references... `PartialEq` already takes both operands by reference, making these implementations useless in practice.

Resolves: #375