### PR TITLE
Remove the concept of an "uninitialized" `ContractId`

### DIFF
--- a/contracts/callcenter/src/lib.rs
+++ b/contracts/callcenter/src/lib.rs
@@ -76,19 +76,17 @@ impl Callcenter {
     }
 
     /// Return the caller of this contract
-    pub fn return_caller(&self) -> ContractId {
+    pub fn return_caller(&self) -> Option<ContractId> {
         uplink::caller()
     }
 
     /// Make sure that the caller of this contract is the contract itself
     pub fn call_self(&self) -> Result<bool, ContractError> {
         let self_id = uplink::self_id();
-        let caller = uplink::caller();
-
-        match caller.is_uninitialized() {
-            true => uplink::call(self_id, "call_self", &())
+        match uplink::caller() {
+            None => uplink::call(self_id, "call_self", &())
                 .expect("querying self should succeed"),
-            false => Ok(caller == self_id),
+            Some(caller) => Ok(caller == self_id),
         }
     }
 

--- a/contracts/crossover/src/lib.rs
+++ b/contracts/crossover/src/lib.rs
@@ -79,7 +79,8 @@ impl Crossover {
     ) {
         self.set_crossover(value_to_set);
 
-        let caller = uplink::caller();
+        let caller =
+            uplink::caller().expect("Should be called by another contract");
         uplink::debug!("calling back {caller:?}");
 
         uplink::call::<_, ()>(caller, "set_crossover", &value_to_set_back)

--- a/contracts/spender/src/lib.rs
+++ b/contracts/spender/src/lib.rs
@@ -25,7 +25,7 @@ impl Spender {
         let limit = uplink::limit();
         let spent_before = uplink::spent();
 
-        match uplink::caller().is_uninitialized() {
+        match uplink::caller().is_none() {
             // if this contract has not been called by another contract,
             // i.e. has been called directly from the outside, call the function
             // via the host and return the limit and spent values before and

--- a/piecrust-uplink/CHANGELOG.md
+++ b/piecrust-uplink/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `impl PartialEq<[u8; 32]> for ContractId` [#375]
 
+### Changed
+
+- Change `callee` function to return `Option<ContractId>`
+- Change `callee` ABI to return an integer
+
 ## [0.15.0] - 2024-07-03
 
 ### Fixed

--- a/piecrust-uplink/src/types.rs
+++ b/piecrust-uplink/src/types.rs
@@ -63,13 +63,6 @@ pub const CONTRACT_ID_BYTES: usize = 32;
 pub struct ContractId([u8; CONTRACT_ID_BYTES]);
 
 impl ContractId {
-    /// Creates a placeholder [`ContractId`] until the host deploys the contract
-    /// and sets a real [`ContractId`]. This can also be used to determine if a
-    /// contract is the first to be called.
-    pub const fn uninitialized() -> Self {
-        ContractId([0u8; CONTRACT_ID_BYTES])
-    }
-
     /// Creates a new [`ContractId`] from an array of bytes
     pub const fn from_bytes(bytes: [u8; CONTRACT_ID_BYTES]) -> Self {
         Self(bytes)
@@ -90,12 +83,6 @@ impl ContractId {
     /// [`ContractId`]
     pub fn as_bytes_mut(&mut self) -> &mut [u8] {
         &mut self.0
-    }
-
-    /// Determines whether the [`ContractId`] is uninitialized, which can be
-    /// used to check if this contract is the first to be called.
-    pub fn is_uninitialized(&self) -> bool {
-        self == &Self::uninitialized()
     }
 }
 

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change `callee` import to return an integer
+
 ## [0.22.0] - 2024-07-03
 
 ### Added

--- a/piecrust/src/session.rs
+++ b/piecrust/src/session.rs
@@ -12,7 +12,9 @@ use std::sync::{mpsc, Arc};
 
 use bytecheck::CheckBytes;
 use dusk_wasmtime::{Engine, LinearMemory, MemoryCreator, MemoryType};
-use piecrust_uplink::{ContractId, Event, ARGBUF_LEN, SCRATCH_BUF_BYTES};
+use piecrust_uplink::{
+    ContractId, Event, ARGBUF_LEN, CONTRACT_ID_BYTES, SCRATCH_BUF_BYTES,
+};
 use rkyv::ser::serializers::{
     BufferScratch, BufferSerializer, CompositeSerializer,
 };
@@ -138,7 +140,7 @@ impl Session {
         data: SessionData,
     ) -> Self {
         let inner = SessionInner {
-            current: ContractId::uninitialized(),
+            current: ContractId::from_bytes([0; CONTRACT_ID_BYTES]),
             call_tree: CallTree::new(),
             instances: BTreeMap::new(),
             debug: vec![],

--- a/piecrust/tests/callcenter.rs
+++ b/piecrust/tests/callcenter.rs
@@ -235,9 +235,9 @@ pub fn cc_caller_uninit() -> Result<(), Error> {
         LIMIT,
     )?;
 
-    let caller: ContractId =
+    let caller: Option<ContractId> =
         session.call(center_id, "return_caller", &(), LIMIT)?.data;
-    assert_eq!(caller, ContractId::uninitialized());
+    assert_eq!(caller, None);
 
     Ok(())
 }


### PR DESCRIPTION
We remove the concept of a `ContractId` being "uninitialized" and all related functionality, and in its place put in an improved ABI, using an integer to signal whether there is a caller or not. These two concepts are semantically equivalent, with the exception that in the former the contract at "zero" `ContractId` is not a possible caller - instead being considered "uninitialized".

As a consequence, we can return `Option<ContractId>` from `piecrust_uplink::caller`, which is a much clearer and more ergonomic API.