### PR TITLE
Fix behavior on calling non-existent contracts

### DIFF
--- a/contracts/double_counter/src/lib.rs
+++ b/contracts/double_counter/src/lib.rs
@@ -10,6 +10,7 @@
 #![no_std]
 
 use piecrust_uplink as uplink;
+use uplink::{ContractError, ContractId};
 
 /// Struct that describes the state of the DoubleCounter contract
 pub struct DoubleCounter {
@@ -40,6 +41,20 @@ impl DoubleCounter {
         let value = self.right_value + 1;
         self.right_value = value;
     }
+
+    /// Increment the counter by 1 and call the given contract, with the given
+    /// arguments.
+    ///
+    /// This is intended to test the behavior of the contract on calling a
+    /// contract that doesn't exist.
+    pub fn increment_left_and_call(
+        &mut self,
+        contract: ContractId,
+    ) -> Result<(), ContractError> {
+        let value = self.left_value + 1;
+        self.left_value = value;
+        uplink::call(contract, "hello", &())
+    }
 }
 
 /// Expose `Counter::read_value()` to the host
@@ -58,4 +73,12 @@ unsafe fn increment_left(arg_len: u32) -> u32 {
 #[no_mangle]
 unsafe fn increment_right(arg_len: u32) -> u32 {
     uplink::wrap_call(arg_len, |_: ()| STATE.increment_right())
+}
+
+/// Expose `Counter::increment_and_call()` to the host
+#[no_mangle]
+unsafe fn increment_left_and_call(arg_len: u32) -> u32 {
+    uplink::wrap_call_unchecked(arg_len, |arg| {
+        STATE.increment_left_and_call(arg)
+    })
 }

--- a/piecrust-uplink/CHANGELOG.md
+++ b/piecrust-uplink/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `ContractError::DoesNotExist` variant
+
 ## [0.16.0] - 2024-08-01
 
 ### Added

--- a/piecrust-uplink/src/error.rs
+++ b/piecrust-uplink/src/error.rs
@@ -27,6 +27,7 @@ use core::str;
 pub enum ContractError {
     Panic(String),
     OutOfGas,
+    DoesNotExist,
     Unknown,
 }
 
@@ -57,6 +58,7 @@ impl ContractError {
         match code {
             -1 => Self::Panic(get_msg(slice)),
             -2 => Self::OutOfGas,
+            -3 => Self::DoesNotExist,
             i32::MIN => Self::Unknown,
             _ => unreachable!("The host must guarantee that the code is valid"),
         }
@@ -81,6 +83,7 @@ impl ContractError {
                 -1
             }
             Self::OutOfGas => -2,
+            Self::DoesNotExist => -3,
             Self::Unknown => i32::MIN,
         }
     }
@@ -91,6 +94,7 @@ impl From<ContractError> for i32 {
         match err {
             ContractError::Panic(_) => -1,
             ContractError::OutOfGas => -2,
+            ContractError::DoesNotExist => -3,
             ContractError::Unknown => i32::MIN,
         }
     }
@@ -101,6 +105,9 @@ impl Display for ContractError {
         match self {
             ContractError::Panic(msg) => write!(f, "Panic: {msg}"),
             ContractError::OutOfGas => write!(f, "OutOfGas"),
+            ContractError::DoesNotExist => {
+                write!(f, "Contract does not exist")
+            }
             ContractError::Unknown => write!(f, "Unknown"),
         }
     }

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Fix behavior of calling a non-existent contract in `c` import
+
 ## [0.23.0] - 2024-08-01
 
 ### Changed

--- a/piecrust/src/error.rs
+++ b/piecrust/src/error.rs
@@ -128,6 +128,7 @@ impl From<Error> for ContractError {
         match err {
             Error::OutOfGas => Self::OutOfGas,
             Error::Panic(msg) => Self::Panic(msg),
+            Error::ContractDoesNotExist(_) => Self::DoesNotExist,
             _ => Self::Unknown,
         }
     }

--- a/piecrust/tests/deploy.rs
+++ b/piecrust/tests/deploy.rs
@@ -4,8 +4,10 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use piecrust::{contract_bytecode, ContractData, Error, SessionData, VM};
-use piecrust_uplink::ContractId;
+use piecrust::{
+    contract_bytecode, ContractData, ContractError, ContractId, Error,
+    SessionData, VM,
+};
 
 const OWNER: [u8; 32] = [0u8; 32];
 const LIMIT: u64 = 1_000_000;
@@ -41,6 +43,44 @@ pub fn deploy_with_id() -> Result<(), Error> {
             .data,
         0xfd
     );
+
+    Ok(())
+}
+
+#[test]
+fn call_non_deployed() -> Result<(), Error> {
+    let vm = VM::ephemeral()?;
+
+    let bytecode = contract_bytecode!("double_counter");
+    let counter_id = ContractId::from_bytes([1; 32]);
+    let mut session = vm.session(SessionData::builder())?;
+    session.deploy(
+        bytecode,
+        ContractData::builder().owner(OWNER).contract_id(counter_id),
+        LIMIT,
+    )?;
+
+    let (value, _) = session
+        .call::<_, (i64, i64)>(counter_id, "read_values", &(), LIMIT)?
+        .data;
+    assert_eq!(value, 0xfc);
+
+    let bogus_id = ContractId::from_bytes([255; 32]);
+    let r = session
+        .call::<_, Result<(), ContractError>>(
+            counter_id,
+            "increment_left_and_call",
+            &bogus_id,
+            LIMIT,
+        )?
+        .data;
+
+    assert!(matches!(r, Err(ContractError::DoesNotExist)));
+
+    let (value, _) = session
+        .call::<_, (i64, i64)>(counter_id, "read_values", &(), LIMIT)?
+        .data;
+    assert_eq!(value, 0xfd);
 
     Ok(())
 }


### PR DESCRIPTION
The path when a contract calls another contract which does not exist was not handled, and would lead to a panic of the entire execution when it does. This PR fixes this by introducing a new error path in the `c` import that *does not* revert, and a new `ContractError::DoesNotExist` variant.