### PR TITLE
Add additional "raw" calls

### DIFF
--- a/contracts/eventer/src/lib.rs
+++ b/contracts/eventer/src/lib.rs
@@ -27,6 +27,13 @@ impl Eventer {
         }
     }
 
+    /// Emits an event with the given number, using `emit_raw`
+    pub fn emit_num_raw(&mut self, num: u32) {
+        for i in 0..num {
+            uplink::emit_raw("number", i.to_le_bytes());
+        }
+    }
+
     pub fn emit_input(&mut self, input: Vec<u8>) -> (u64, u64) {
         let spent_before = uplink::spent();
         uplink::emit("input", input);
@@ -39,6 +46,12 @@ impl Eventer {
 #[no_mangle]
 unsafe fn emit_events(arg_len: u32) -> u32 {
     uplink::wrap_call(arg_len, |num| STATE.emit_num(num))
+}
+
+/// Expose `Eventer::emit_num_raw()` to the host
+#[no_mangle]
+unsafe fn emit_events_raw(arg_len: u32) -> u32 {
+    uplink::wrap_call(arg_len, |num| STATE.emit_num_raw(num))
 }
 
 /// Expose `Eventer::emit_input()` to the host

--- a/contracts/feeder/src/lib.rs
+++ b/contracts/feeder/src/lib.rs
@@ -25,10 +25,23 @@ impl Feeder {
             uplink::feed(i);
         }
     }
+
+    /// Feed the host with 32-bit integers sequentially in the `0..num` range.
+    pub fn feed_num_raw(&self, num: u32) {
+        for i in 0..num {
+            uplink::feed_raw(i.to_le_bytes());
+        }
+    }
 }
 
 /// Expose `Feeder::feed_num()` to the host
 #[no_mangle]
 unsafe fn feed_num(arg_len: u32) -> u32 {
     uplink::wrap_call(arg_len, |num| STATE.feed_num(num))
+}
+
+/// Expose `Feeder::feed_num_raw()` to the host
+#[no_mangle]
+unsafe fn feed_num_raw(arg_len: u32) -> u32 {
+    uplink::wrap_call(arg_len, |num| STATE.feed_num_raw(num))
 }

--- a/piecrust-uplink/CHANGELOG.md
+++ b/piecrust-uplink/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `emit_raw` function
+- Add `emit_raw` and `feed_raw` functions
 - Add `ContractError::DoesNotExist` variant
 
 ## [0.16.0] - 2024-08-01

--- a/piecrust-uplink/CHANGELOG.md
+++ b/piecrust-uplink/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `emit_raw` function
 - Add `ContractError::DoesNotExist` variant
 
 ## [0.16.0] - 2024-08-01

--- a/piecrust/tests/eventer.rs
+++ b/piecrust/tests/eventer.rs
@@ -36,6 +36,23 @@ pub fn vm_center_events() -> Result<(), Error> {
         assert_eq!(events[index].data, i.to_le_bytes());
     }
 
+    let receipt = session.call::<_, ()>(
+        eventer_id,
+        "emit_events_raw",
+        &EVENT_NUM,
+        LIMIT,
+    )?;
+
+    let events = receipt.events;
+    assert_eq!(events.len() as u32, EVENT_NUM);
+
+    for i in 0..EVENT_NUM {
+        let index = i as usize;
+        assert_eq!(events[index].source, eventer_id);
+        assert_eq!(events[index].topic, "number");
+        assert_eq!(events[index].data, i.to_le_bytes());
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
This PR adds two other "raw" calls in `piecrust-uplink`, meant to allow the user to perform their own custom serialization in contract. `emit_raw` and `feed_raw` make sure that any serialization that the contract developer wishes to use is supported, as opposed to only `rkyv`, in the same way as `call` and `call_raw` already work.