### PR TITLE
Remove `'static` bound on `emit` topics

### DIFF
--- a/piecrust-uplink/CHANGELOG.md
+++ b/piecrust-uplink/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `emit_raw` and `feed_raw` functions
 - Add `ContractError::DoesNotExist` variant
 
+### Changed
+
+- Remove `'static` bound on `emit` topics
+
 ## [0.16.0] - 2024-08-01
 
 ### Added

--- a/piecrust-uplink/src/abi/state.rs
+++ b/piecrust-uplink/src/abi/state.rs
@@ -300,7 +300,7 @@ pub fn spent() -> u64 {
 }
 
 /// Emits an event with the given data, serializing it using [`rkyv`].
-pub fn emit<D>(topic: &'static str, data: D)
+pub fn emit<D>(topic: &str, data: D)
 where
     for<'a> D: Serialize<StandardBufSerializer<'a>>,
 {
@@ -322,7 +322,7 @@ where
 }
 
 /// Emits an event with the given data.
-pub fn emit_raw(topic: &'static str, data: impl AsRef<[u8]>) {
+pub fn emit_raw(topic: &str, data: impl AsRef<[u8]>) {
     with_arg_buf(|buf| {
         let data = data.as_ref();
 


### PR DESCRIPTION
Pretty self-explanatory. The `'static` bound was there because we though users should be stimulated to define their event types, but since this is not a real constraint, we remove it.