### PR TITLE
Release 0.24.0

### DIFF
--- a/piecrust-uplink/CHANGELOG.md
+++ b/piecrust-uplink/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0] - 2024-09-04
+
 ### Added
 
 - Add `emit_raw` and `feed_raw` functions
@@ -233,7 +235,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#136]: https://github.com/dusk-network/piecrust/issues/136
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/uplink-0.16.0...HEAD
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/uplink-0.17.0...HEAD
+[0.17.0]: https://github.com/dusk-network/piecrust/compare/uplink-0.16.0...uplink-0.17.0
 [0.16.0]: https://github.com/dusk-network/piecrust/compare/uplink-0.15.0...uplink-0.16.0
 [0.15.0]: https://github.com/dusk-network/piecrust/compare/uplink-0.14.0...uplink-0.15.0
 [0.14.0]: https://github.com/dusk-network/piecrust/compare/uplink-0.13.0...uplink-0.14.0

--- a/piecrust-uplink/Cargo.toml
+++ b/piecrust-uplink/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.16.0"
+version = "0.17.0"
 
 edition = "2021"
 license = "MPL-2.0"

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.0] - 2024-09-04
+
 ### Changed
 
 - Fix behavior of calling a non-existent contract in `c` import
@@ -504,7 +506,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- VERSIONS -->
 
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/piecrust-0.23.0...HEAD
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/piecrust-0.24.0...HEAD
+[0.24.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.23.0...piecrust-0.24.0
 [0.23.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.22.0...piecrust-0.23.0
 [0.22.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.21.0...piecrust-0.22.0
 [0.21.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.20.0...piecrust-0.21.0

--- a/piecrust/Cargo.toml
+++ b/piecrust/Cargo.toml
@@ -7,14 +7,14 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.23.0"
+version = "0.24.0"
 
 edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
 crumbles = { version = "0.3", path = "../crumbles" }
-piecrust-uplink = { version = "0.16", path = "../piecrust-uplink" }
+piecrust-uplink = { version = "0.17", path = "../piecrust-uplink" }
 
 dusk-wasmtime = { version = "21.0.0-alpha", default-features = false, features = ["cranelift", "runtime", "parallel-compilation"] }
 bytecheck = "0.6"


### PR DESCRIPTION
## [piecrust 0.24.0] - 2024-09-04

### Changed

- Fix behavior of calling a non-existent contract in `c` import

## [uplink 0.17.0] - 2024-09-04

### Added

- Add `emit_raw` and `feed_raw` functions
- Add `ContractError::DoesNotExist` variant

### Changed

- Remove `'static` bound on `emit` topics

[piecrust 0.24.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.23.0...piecrust-0.24.0
[uplink 0.17.0]: https://github.com/dusk-network/piecrust/compare/uplink-0.16.0...uplink-0.17.0
