### PR TITLE
uplink: increase scratch size to 1024

### DIFF
--- a/piecrust-uplink/CHANGELOG.md
+++ b/piecrust-uplink/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Increase `SCRATCH_BUF_BYTES` to 1024
+
 ## [0.17.0] - 2024-09-04
 
 ### Added

--- a/piecrust-uplink/src/lib.rs
+++ b/piecrust-uplink/src/lib.rs
@@ -79,7 +79,7 @@ mod error;
 pub use error::*;
 
 /// How many bytes to use for scratch space when serializing
-pub const SCRATCH_BUF_BYTES: usize = 64;
+pub const SCRATCH_BUF_BYTES: usize = 1024;
 
 /// The size of the argument buffer in bytes
 pub const ARGBUF_LEN: usize = 64 * 1024;


### PR DESCRIPTION
More scratch size allows for serializing more complex structures. This PR increases the scratch size from 64 bytes to 1024 bytes, leaving ample room for complex serializations.

Downstream in [`rusk`](https://github.com/dusk-network/rusk), we need this to be able to serialize a large vector of rewards to provisioners.