### PR TITLE
Write commit time improvements

### DIFF
--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Improved commit writing time [#388]
 - Changed state representation to improve commit performance [#342]
 
 ## [0.24.0] - 2024-09-04
@@ -465,6 +466,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- ISSUES -->
 
+[#388]: https://github.com/dusk-network/piecrust/issues/388
 [#371]: https://github.com/dusk-network/piecrust/issues/371
 [#359]: https://github.com/dusk-network/piecrust/issues/359
 [#357]: https://github.com/dusk-network/piecrust/issues/357

--- a/piecrust/src/store/session.rs
+++ b/piecrust/src/store/session.rs
@@ -155,7 +155,6 @@ impl ContractSession {
         receiver
             .recv()
             .expect("The receiver should always receive a reply")
-            .map(|c| *c.index.root())
     }
 
     /// Returns path to a file representing a given commit and page.


### PR DESCRIPTION
Write commit time improvements decrease the commit persistence time by more than 30%.
This is achieved by extra commit clone removal, extra commit retrieval removal, and index serialisation optimisation.

Implements issue #388 
