### PR TITLE
separated base info from index

### DIFF
--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Improved page finding performance [#393]
+
 ## [0.25.0] - 2024-09-30
 
 ### Changed
@@ -468,6 +472,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- ISSUES -->
 
+[#393]: https://github.com/dusk-network/piecrust/issues/393
 [#388]: https://github.com/dusk-network/piecrust/issues/388
 [#371]: https://github.com/dusk-network/piecrust/issues/371
 [#359]: https://github.com/dusk-network/piecrust/issues/359

--- a/piecrust/Cargo.toml
+++ b/piecrust/Cargo.toml
@@ -27,6 +27,7 @@ rand = "0.8"
 hex = "0.4"
 dusk-merkle = { version = "0.5", features = ["rkyv-impl"] }
 const-decoder = "0.3"
+tracing = "=0.1.40"
 
 [dev-dependencies]
 once_cell = "1.18"

--- a/piecrust/Cargo.toml
+++ b/piecrust/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.25.0"
+version = "0.25.1-rc.0"
 
 edition = "2021"
 license = "MPL-2.0"

--- a/piecrust/src/store/session.rs
+++ b/piecrust/src/store/session.rs
@@ -17,8 +17,8 @@ use piecrust_uplink::ContractId;
 use crate::contract::ContractMetadata;
 use crate::store::tree::{Hash, PageOpening};
 use crate::store::{
-    index_from_path, Bytecode, Call, Commit, Memory, Metadata, Module,
-    BYTECODE_DIR, INDEX_FILE, MAIN_DIR, MEMORY_DIR, METADATA_EXTENSION,
+    base_from_path, Bytecode, Call, Commit, Memory, Metadata, Module,
+    BASE_FILE, BYTECODE_DIR, MAIN_DIR, MEMORY_DIR, METADATA_EXTENSION,
     OBJECTCODE_EXTENSION, PAGE_SIZE,
 };
 use crate::Error;
@@ -178,9 +178,9 @@ impl ContractSession {
                 if path.is_file() {
                     Some(path)
                 } else {
-                    let index_path =
-                        main_path.as_ref().join(hash_hex).join(INDEX_FILE);
-                    let index = index_from_path(index_path).ok()?;
+                    let base_info_path =
+                        main_path.as_ref().join(hash_hex).join(BASE_FILE);
+                    let index = base_from_path(base_info_path).ok()?;
                     Self::find_page(
                         page_index,
                         index.maybe_base,

--- a/piecrust/src/store/tree.rs
+++ b/piecrust/src/store/tree.rs
@@ -79,28 +79,28 @@ pub type Tree = dusk_merkle::Tree<Hash, C_HEIGHT, C_ARITY>;
 
 #[derive(Debug, Clone, Archive, Deserialize, Serialize)]
 #[archive_attr(derive(CheckBytes))]
-pub struct ContractIndex {
-    tree: Tree,
-    contracts: BTreeMap<ContractId, ContractIndexElement>,
+pub struct NewContractIndex {
+    pub tree: Tree,
+    pub contracts: BTreeMap<ContractId, ContractIndexElement>,
 }
 
 #[derive(Debug, Clone, Archive, Deserialize, Serialize)]
+#[archive_attr(derive(CheckBytes))]
+pub struct ContractIndex {
+    pub tree: Tree,
+    pub contracts: BTreeMap<ContractId, ContractIndexElement>,
+    pub contract_hints: Vec<ContractId>,
+    pub maybe_base: Option<Hash>,
+}
+
+#[derive(Debug, Clone, Default, Archive, Deserialize, Serialize)]
 #[archive_attr(derive(CheckBytes))]
 pub struct BaseInfo {
     pub contract_hints: Vec<ContractId>,
     pub maybe_base: Option<Hash>,
 }
 
-impl Default for BaseInfo {
-    fn default() -> Self {
-        Self {
-            contract_hints: Vec::new(),
-            maybe_base: None,
-        }
-    }
-}
-
-impl Default for ContractIndex {
+impl Default for NewContractIndex {
     fn default() -> Self {
         Self {
             tree: Tree::new(),
@@ -109,7 +109,7 @@ impl Default for ContractIndex {
     }
 }
 
-impl ContractIndex {
+impl NewContractIndex {
     pub fn inclusion_proofs(
         mut self,
         contract_id: &ContractId,
@@ -148,7 +148,7 @@ pub struct ContractIndexElement {
     pub page_indices: BTreeSet<usize>,
 }
 
-impl ContractIndex {
+impl NewContractIndex {
     pub fn insert(&mut self, contract: ContractId, memory: &Memory) {
         if self.contracts.get(&contract).is_none() {
             self.contracts.insert(

--- a/piecrust/src/store/tree.rs
+++ b/piecrust/src/store/tree.rs
@@ -82,8 +82,22 @@ pub type Tree = dusk_merkle::Tree<Hash, C_HEIGHT, C_ARITY>;
 pub struct ContractIndex {
     tree: Tree,
     contracts: BTreeMap<ContractId, ContractIndexElement>,
+}
+
+#[derive(Debug, Clone, Archive, Deserialize, Serialize)]
+#[archive_attr(derive(CheckBytes))]
+pub struct BaseInfo {
     pub contract_hints: Vec<ContractId>,
     pub maybe_base: Option<Hash>,
+}
+
+impl Default for BaseInfo {
+    fn default() -> Self {
+        Self {
+            contract_hints: Vec::new(),
+            maybe_base: None,
+        }
+    }
 }
 
 impl Default for ContractIndex {
@@ -91,8 +105,6 @@ impl Default for ContractIndex {
         Self {
             tree: Tree::new(),
             contracts: BTreeMap::new(),
-            contract_hints: Vec::new(),
-            maybe_base: None,
         }
     }
 }


### PR DESCRIPTION
To address page finding performance problem, separated base info file from the index file, thus speeding up access to base info and making it O(1) rather than dependent on the size of the index file

Implements issue #393
