### PR TITLE
piecrust: bump to version 0.26.0

### DIFF
--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.0] - 2024-10-21
+
 ### Changed
 
 - Improved performance of commit operations [#396]
@@ -522,7 +524,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- VERSIONS -->
 
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/piecrust-0.25.0...HEAD
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/piecrust-0.26.0...HEAD
+[0.26.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.25.0...piecrust-0.26.0
 [0.25.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.24.0...piecrust-0.25.0
 [0.24.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.23.0...piecrust-0.24.0
 [0.23.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.22.0...piecrust-0.23.0

--- a/piecrust/Cargo.toml
+++ b/piecrust/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.26.0-rc.3"
+version = "0.26.0"
 
 edition = "2021"
 license = "MPL-2.0"


### PR DESCRIPTION
piecrust: bump to version 0.26.0

addresses issue #396 