### PR TITLE
Optimise contract session to hold a base commit without a copy of contract index

### DIFF
--- a/piecrust/src/store.rs
+++ b/piecrust/src/store.rs
@@ -29,7 +29,7 @@ use piecrust_uplink::ContractId;
 use session::ContractDataEntry;
 use tree::{Hash, NewContractIndex};
 
-use crate::store::commit::CommitClone;
+use crate::store::commit::CommitHulk;
 use crate::store::tree::{
     position_from_contract, BaseInfo, ContractIndexElement, ContractsMerkle,
     PageTree,
@@ -241,7 +241,7 @@ impl ContractStore {
                 .lock()
                 .unwrap()
                 .get_commit(&hash)
-                .map(|commit| commit.to_clone()) // todo: clone here
+                .map(|commit| commit.to_hulk())
         });
         ContractSession::new(
             &self.root_dir,
@@ -526,8 +526,8 @@ impl Commit {
         }
     }
 
-    pub fn to_clone(&self) -> CommitClone {
-        CommitClone::from_commit(self)
+    pub fn to_hulk(&self) -> CommitHulk {
+        CommitHulk::from_commit(self)
     }
 
     #[allow(dead_code)]

--- a/piecrust/src/store/commit.rs
+++ b/piecrust/src/store/commit.rs
@@ -1,0 +1,221 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use crate::store::tree::{
+    position_from_contract, ContractIndexElement, ContractsMerkle, Hash,
+    NewContractIndex, PageTree,
+};
+use crate::store::{Commit, Memory};
+use crate::PageOpening;
+use piecrust_uplink::ContractId;
+use std::cell::Ref;
+use std::collections::BTreeSet;
+
+#[derive(Debug, Clone)]
+pub(crate) struct CommitClone {
+    index: Option<*const NewContractIndex>,
+    index2: NewContractIndex,
+    contracts_merkle: ContractsMerkle,
+    maybe_hash: Option<Hash>,
+}
+
+impl CommitClone {
+    pub fn from_commit(commit: &Commit) -> Self {
+        Self {
+            index: Some(&commit.index),
+            index2: NewContractIndex::new(),
+            contracts_merkle: commit.contracts_merkle.clone(),
+            maybe_hash: commit.maybe_hash,
+        }
+    }
+
+    pub fn new() -> Self {
+        Self {
+            index: None,
+            index2: NewContractIndex::new(),
+            contracts_merkle: ContractsMerkle::default(),
+            maybe_hash: None,
+        }
+    }
+
+    pub fn to_commit(&self) -> Commit {
+        let index = self.index.map(|p| unsafe { p.as_ref().unwrap() });
+        let mut commit = match index {
+            Some(p) => Commit {
+                index: p.clone(),
+                contracts_merkle: self.contracts_merkle.clone(),
+                maybe_hash: self.maybe_hash,
+            },
+            None => Commit {
+                index: NewContractIndex::new(),
+                contracts_merkle: self.contracts_merkle.clone(),
+                maybe_hash: self.maybe_hash,
+            },
+        };
+        for (contract_id, element) in self.index2.contracts().iter() {
+            commit
+                .index
+                .insert_contract_index(&contract_id, element.clone())
+        }
+        commit
+    }
+
+    pub fn fast_clone<'a>(
+        &self,
+        contract_ids: impl Iterator<Item = &'a ContractId>,
+    ) -> Self {
+        let mut index2 = NewContractIndex::new();
+        for contract_id in contract_ids {
+            if let Some(a) = self.index_get(contract_id) {
+                index2.insert_contract_index(contract_id, a.clone());
+            }
+        }
+        Self {
+            index: None,
+            index2,
+            contracts_merkle: self.contracts_merkle.clone(),
+            maybe_hash: self.maybe_hash,
+        }
+    }
+
+    pub fn inclusion_proofs(
+        mut self,
+        contract_id: &ContractId,
+    ) -> Option<impl Iterator<Item = (usize, PageOpening)>> {
+        let contract = self.remove_contract_index(contract_id)?;
+
+        let pos = position_from_contract(contract_id);
+
+        Some(contract.page_indices.into_iter().map(move |page_index| {
+            let tree_opening = self
+                .contracts_merkle
+                .opening(pos)
+                .expect("There must be a leaf for the contract");
+
+            let page_opening = contract
+                .tree
+                .opening(page_index as u64)
+                .expect("There must be a leaf for the page");
+
+            (
+                page_index,
+                PageOpening {
+                    tree: tree_opening,
+                    inner: page_opening,
+                },
+            )
+        }))
+    }
+
+    pub fn insert(&mut self, contract_id: ContractId, memory: &Memory) {
+        if self.index_get(&contract_id).is_none() {
+            self.insert_contract_index(
+                &contract_id,
+                ContractIndexElement {
+                    tree: PageTree::new(memory.is_64()),
+                    len: 0,
+                    page_indices: BTreeSet::new(),
+                    hash: None,
+                    int_pos: None,
+                },
+            );
+        }
+        let (index2, contracts_merkle) = self.get_mutables();
+        let element = index2.get_mut(&contract_id, None).unwrap();
+
+        element.len = memory.current_len;
+
+        for (dirty_page, _, page_index) in memory.dirty_pages() {
+            element.page_indices.insert(*page_index);
+            let hash = Hash::new(dirty_page);
+            element.tree.insert(*page_index as u64, hash);
+        }
+
+        let root = element.tree.root();
+        let pos = position_from_contract(&contract_id);
+        let int_pos = contracts_merkle.insert(pos, *root);
+        element.hash = Some(*root);
+        element.int_pos = Some(int_pos);
+    }
+
+    // to satisfy borrow checker
+    fn get_mutables(
+        &mut self,
+    ) -> (&mut NewContractIndex, &mut ContractsMerkle) {
+        (&mut self.index2, &mut self.contracts_merkle)
+    }
+
+    // pub fn remove_and_insert(&mut self, contract: ContractId, memory:
+    // &Memory) {     self.remove_contract_index(&contract);
+    //     self.insert(contract, memory);
+    // }
+
+    pub fn root(&self) -> Ref<Hash> {
+        tracing::trace!("calculating root started");
+        let ret = self.contracts_merkle.root();
+        tracing::trace!("calculating root finished");
+        ret
+    }
+
+    /*
+    ==========================
+     */
+
+    pub fn remove_contract_index(
+        &mut self,
+        contract_id: &ContractId,
+    ) -> Option<ContractIndexElement> {
+        self.index2.contracts_mut().remove(&contract_id) // todo: may not work
+    }
+
+    pub fn insert_contract_index(
+        &mut self,
+        contract_id: &ContractId,
+        element: ContractIndexElement,
+    ) {
+        self.index2.contracts_mut().insert(*contract_id, element);
+    }
+
+    pub fn index_get(
+        &self,
+        contract_id: &ContractId,
+    ) -> Option<&ContractIndexElement> {
+        let index = self.index.map(|p| unsafe { p.as_ref().unwrap() });
+        match index {
+            Some(p) => self
+                .index2
+                .get(&contract_id, self.maybe_hash)
+                .or_else(move || p.get(&contract_id, self.maybe_hash)),
+            None => self.index2.get(&contract_id, self.maybe_hash),
+        }
+    }
+
+    // note, does not allow changing the original
+    // pub fn index_get_mut(
+    //     &mut self,
+    //     contract_id: &ContractId,
+    // ) -> Option<&mut ContractIndexElement> {
+    //     self.index2
+    //         .get_mut(&contract_id, self.maybe_hash)
+    // }
+
+    pub fn index_contains_key(&self, contract_id: &ContractId) -> bool {
+        let index = self.index.map(|p| unsafe { p.as_ref().unwrap() });
+        match index {
+            Some(p) => {
+                self.index2.contains_key(&contract_id)
+                    || p.contains_key(&contract_id)
+            }
+            None => self.index2.contains_key(&contract_id),
+        }
+    }
+
+    // pub fn index_iter(
+    //     &self,
+    // ) -> impl Iterator<Item = (&(ContractId, u8), &ContractIndexElement)> {
+    //     self.index.contracts().iter()
+    // }
+}

--- a/piecrust/src/store/commit.rs
+++ b/piecrust/src/store/commit.rs
@@ -43,7 +43,7 @@ impl CommitHulk {
 
     pub fn to_commit(&self) -> Commit {
         let index = self.index.map(|p| unsafe { p.as_ref().unwrap() });
-        let mut commit = match index {
+        match index {
             Some(p) => Commit {
                 index: p.clone(),
                 contracts_merkle: self.contracts_merkle.clone(),
@@ -54,13 +54,12 @@ impl CommitHulk {
                 contracts_merkle: self.contracts_merkle.clone(),
                 maybe_hash: self.maybe_hash,
             },
-        };
-        for (contract_id, element) in self.index2.contracts().iter() {
-            commit
-                .index
-                .insert_contract_index(&contract_id, element.clone())
         }
-        commit
+        // for (contract_id, element) in self.index2.contracts().iter() {
+        //     commit
+        //         .index
+        //         .insert_contract_index(&contract_id, element.clone())
+        // }
     }
 
     pub fn fast_clone<'a>(
@@ -123,8 +122,8 @@ impl CommitHulk {
                 },
             );
         }
-        let (index2, contracts_merkle) = self.get_mutables();
-        let element = index2.get_mut(&contract_id, None).unwrap();
+        let (index, contracts_merkle) = self.get_mutables();
+        let element = index.get_mut(&contract_id, None).unwrap();
 
         element.len = memory.current_len;
 
@@ -161,14 +160,14 @@ impl CommitHulk {
     }
 
     /*
-    ==========================
+    index accessors
      */
 
     pub fn remove_contract_index(
         &mut self,
         contract_id: &ContractId,
     ) -> Option<ContractIndexElement> {
-        self.index2.contracts_mut().remove(&contract_id) // todo: may not work
+        self.index2.contracts_mut().remove(contract_id)
     }
 
     pub fn insert_contract_index(
@@ -187,9 +186,9 @@ impl CommitHulk {
         match index {
             Some(p) => self
                 .index2
-                .get(&contract_id, self.maybe_hash)
-                .or_else(move || p.get(&contract_id, self.maybe_hash)),
-            None => self.index2.get(&contract_id, self.maybe_hash),
+                .get(contract_id, self.maybe_hash)
+                .or_else(move || p.get(contract_id, self.maybe_hash)),
+            None => self.index2.get(contract_id, self.maybe_hash),
         }
     }
 
@@ -206,10 +205,10 @@ impl CommitHulk {
         let index = self.index.map(|p| unsafe { p.as_ref().unwrap() });
         match index {
             Some(p) => {
-                self.index2.contains_key(&contract_id)
-                    || p.contains_key(&contract_id)
+                self.index2.contains_key(contract_id)
+                    || p.contains_key(contract_id)
             }
-            None => self.index2.contains_key(&contract_id),
+            None => self.index2.contains_key(contract_id),
         }
     }
 

--- a/piecrust/src/store/commit.rs
+++ b/piecrust/src/store/commit.rs
@@ -15,14 +15,14 @@ use std::cell::Ref;
 use std::collections::BTreeSet;
 
 #[derive(Debug, Clone)]
-pub(crate) struct CommitClone {
+pub(crate) struct CommitHulk {
     index: Option<*const NewContractIndex>,
     index2: NewContractIndex,
     contracts_merkle: ContractsMerkle,
     maybe_hash: Option<Hash>,
 }
 
-impl CommitClone {
+impl CommitHulk {
     pub fn from_commit(commit: &Commit) -> Self {
         Self {
             index: Some(&commit.index),

--- a/piecrust/src/store/commit.rs
+++ b/piecrust/src/store/commit.rs
@@ -55,11 +55,6 @@ impl CommitHulk {
                 maybe_hash: self.maybe_hash,
             },
         }
-        // for (contract_id, element) in self.index2.contracts().iter() {
-        //     commit
-        //         .index
-        //         .insert_contract_index(&contract_id, element.clone())
-        // }
     }
 
     pub fn fast_clone<'a>(
@@ -147,11 +142,6 @@ impl CommitHulk {
         (&mut self.index2, &mut self.contracts_merkle)
     }
 
-    // pub fn remove_and_insert(&mut self, contract: ContractId, memory:
-    // &Memory) {     self.remove_contract_index(&contract);
-    //     self.insert(contract, memory);
-    // }
-
     pub fn root(&self) -> Ref<Hash> {
         tracing::trace!("calculating root started");
         let ret = self.contracts_merkle.root();
@@ -192,15 +182,6 @@ impl CommitHulk {
         }
     }
 
-    // note, does not allow changing the original
-    // pub fn index_get_mut(
-    //     &mut self,
-    //     contract_id: &ContractId,
-    // ) -> Option<&mut ContractIndexElement> {
-    //     self.index2
-    //         .get_mut(&contract_id, self.maybe_hash)
-    // }
-
     pub fn index_contains_key(&self, contract_id: &ContractId) -> bool {
         let index = self.index.map(|p| unsafe { p.as_ref().unwrap() });
         match index {
@@ -211,10 +192,4 @@ impl CommitHulk {
             None => self.index2.contains_key(contract_id),
         }
     }
-
-    // pub fn index_iter(
-    //     &self,
-    // ) -> impl Iterator<Item = (&(ContractId, u8), &ContractIndexElement)> {
-    //     self.index.contracts().iter()
-    // }
 }

--- a/piecrust/src/store/session.rs
+++ b/piecrust/src/store/session.rs
@@ -146,16 +146,9 @@ impl ContractSession {
         let (replier, receiver) = mpsc::sync_channel(1);
 
         let mut contracts = BTreeMap::new();
-        let base = self.base.as_ref().map(|c| //Commit {
-            // index: c.index.clone(),
-            // contracts_merkle: c.contracts_merkle.clone(),
-            // maybe_hash: c.maybe_hash,
-            c.to_commit() /* } */);
-
-        let mut base_clone = base.as_ref().map(|b| b.to_hulk()); // todo: wasteful, think of a better way
+        let base = self.base.as_ref().map(|c| c.to_commit());
 
         mem::swap(&mut self.contracts, &mut contracts);
-        mem::swap(&mut self.base, &mut base_clone);
 
         self.call
             .send(Call::Commit {

--- a/piecrust/src/store/tree.rs
+++ b/piecrust/src/store/tree.rs
@@ -81,6 +81,17 @@ pub struct NewContractIndex {
     inner_contracts: BTreeMap<ContractId, ContractIndexElement>,
 }
 
+impl NewContractIndex {
+    pub fn contracts(&self) -> &BTreeMap<ContractId, ContractIndexElement> {
+        &self.inner_contracts
+    }
+    pub fn contracts_mut(
+        &mut self,
+    ) -> &mut BTreeMap<ContractId, ContractIndexElement> {
+        &mut self.inner_contracts
+    }
+}
+
 #[derive(Debug, Clone, Archive, Deserialize, Serialize)]
 #[archive_attr(derive(CheckBytes))]
 pub struct ContractsMerkle {


### PR DESCRIPTION
Optimises contract session to hold a base commit without a copy of contract index

Corresponds to a published release `0.26.1-rc.0`


Resolves issue #400