### PR TITLE
fix: typos in documentation files

### DIFF
--- a/.github/workflows/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/workflows/ISSUE_TEMPLATE/bug_report.md
@@ -14,7 +14,7 @@ A clear and concise description of what the bug is.
 if applicable add a *minimum reproducible example*
 
 ```
-// Be exhustive
+// Be exhaustive
 // 
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 The project is organized as follows:
 
-- `contracts`: Contains a number of example smart contracts that can be ran against the `piecrust` virtual machine.
+- `contracts`: Contains a number of example smart contracts that can be run against the `piecrust` virtual machine.
 - `piecrust`: Contains the source code and README for the WASM virtual machine.
 - `piecrust-uplink`: Contains the source code and README for the smart contract development kit.
 

--- a/crumbles/README.md
+++ b/crumbles/README.md
@@ -8,7 +8,7 @@ Crumbles is a Rust library designed for creating and managing copy-on-write memo
 
 ## Usage
 
-The core fuctionality of Crumbles is provided by the `Mmap` struct. This struct offers methods to manage memory regions, create snapshots and revert/apply changes.
+The core functionality of Crumbles is provided by the `Mmap` struct. This struct offers methods to manage memory regions, create snapshots and revert/apply changes.
 
 Add `crumbles` as a dependency to your contract project:
 ```sh

--- a/docs/on-disk-datastore.md
+++ b/docs/on-disk-datastore.md
@@ -30,7 +30,7 @@ and, the directory will contain the following files:
 
 ### Another Commit
 
-When can then start a new session using `root_1` as a base commit, and make some
+We can then start a new session using `root_1` as a base commit, and make some
 modifications to the state by performing transactions. Let's say that we made
 some modifications to `contract_1`'s first memory page, and deploy a new
 contract with identifier `contract_3`. We can then commit to those changes


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected "exhustive" to "exhaustive".
Corrected "fuctionality" to "functionality".
Corrected "When can" to "We can".
Corrected "ran" to "run". It should be "run" instead of "ran" as it refers to an action that can be performed in the future.

Please review the changes and let me know if any additional changes are needed.