### PR TITLE
Store merkle positions in binary formant rather than using rkyv

### DIFF
--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "box",
     "c-example",
     "callcenter",
+    "callstack",
     "initializer",
     "counter",
     "counter_float",

--- a/contracts/callcenter/src/lib.rs
+++ b/contracts/callcenter/src/lib.rs
@@ -80,6 +80,11 @@ impl Callcenter {
         uplink::caller()
     }
 
+    /// Return the entire call stack of this contract
+    pub fn return_callstack(&self) -> Vec<ContractId> {
+        uplink::callstack()
+    }
+
     /// Make sure that the caller of this contract is the contract itself
     pub fn call_self(&self) -> Result<bool, ContractError> {
         let self_id = uplink::self_id();
@@ -151,6 +156,12 @@ unsafe fn return_self_id(arg_len: u32) -> u32 {
 #[no_mangle]
 unsafe fn return_caller(arg_len: u32) -> u32 {
     wrap_call(arg_len, |_: ()| STATE.return_caller())
+}
+
+/// Expose `Callcenter::return_callstack()` to the host
+#[no_mangle]
+unsafe fn return_callstack(arg_len: u32) -> u32 {
+    wrap_call(arg_len, |_: ()| STATE.return_callstack())
 }
 
 /// Expose `Callcenter::delegate_query()` to the host

--- a/contracts/callcenter/src/lib.rs
+++ b/contracts/callcenter/src/lib.rs
@@ -95,6 +95,16 @@ impl Callcenter {
         }
     }
 
+    /// Return a call stack after calling itself n times
+    pub fn call_self_n_times(&self, n: u32) -> Vec<ContractId> {
+        let self_id = uplink::self_id();
+        match n {
+            0 => uplink::callstack(),
+            _ => uplink::call(self_id, "call_self_n_times", &(n - 1))
+                .expect("calling self should succeed")
+        }
+    }
+
     /// Calls the `spend` function of the `contract` with no arguments, and the
     /// given `gas_limit`, assuming the called function returns `()`. It will
     /// then return the call's result itself.
@@ -136,6 +146,12 @@ unsafe fn calling_self(arg_len: u32) -> u32 {
 #[no_mangle]
 unsafe fn call_self(arg_len: u32) -> u32 {
     wrap_call(arg_len, |_: ()| STATE.call_self())
+}
+
+/// Expose `Callcenter::call_self_n_times()` to the host
+#[no_mangle]
+unsafe fn call_self_n_times(arg_len: u32) -> u32 {
+    wrap_call(arg_len, |n: u32| STATE.call_self_n_times(n))
 }
 
 /// Expose `Callcenter::call_spend_with_limit` to the host

--- a/contracts/callstack/Cargo.toml
+++ b/contracts/callstack/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "callstack"
+version = "0.1.0"
+authors = [
+    "Milosz Muszynski <milosz@dusk.network>",
+]
+edition = "2021"
+
+license = "MPL-2.0"
+
+[dependencies]
+piecrust-uplink = { path = "../../piecrust-uplink", features = ["abi", "dlmalloc"] }
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/contracts/callstack/src/lib.rs
+++ b/contracts/callstack/src/lib.rs
@@ -1,0 +1,34 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+//! Contract which exposes the call stack
+
+#![no_std]
+
+extern crate alloc;
+
+use piecrust_uplink as uplink;
+use alloc::vec::Vec;
+use uplink::ContractId;
+
+/// Struct that describes the state of the contract
+pub struct CallStack;
+
+/// State of the Counter contract
+static mut STATE: CallStack = CallStack;
+
+impl CallStack {
+    /// Return the call stack
+    pub fn return_callstack(&self) -> Vec<ContractId> {
+        uplink::callstack()
+    }
+}
+
+/// Expose `CallStack::read_callstack()` to the host
+#[no_mangle]
+unsafe fn return_callstack(arg_len: u32) -> u32 {
+    uplink::wrap_call_unchecked(arg_len, |_: ()| STATE.return_callstack())
+}

--- a/piecrust-uplink/Cargo.toml
+++ b/piecrust-uplink/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.17.1"
+version = "0.17.2-rc.0"
 
 edition = "2021"
 license = "MPL-2.0"

--- a/piecrust-uplink/src/abi/state.rs
+++ b/piecrust-uplink/src/abi/state.rs
@@ -58,6 +58,7 @@ mod ext {
         pub fn feed(arg_len: u32);
 
         pub fn caller() -> i32;
+        pub fn callstack() -> i32;
         pub fn limit() -> u64;
         pub fn spent() -> u64;
         pub fn owner(contract_id: *const u8) -> i32;
@@ -287,6 +288,22 @@ pub fn caller() -> Option<ContractId> {
             Some(ContractId::from_bytes(bytes))
         }),
     }
+}
+
+/// Returns IDs of all calling contracts present in the calling stack
+pub fn callstack() -> Vec<ContractId> {
+    let n = unsafe { ext::callstack() };
+    with_arg_buf(|buf| {
+        let mut v = Vec::new();
+        for i in 0..n as usize {
+            let mut bytes = [0; CONTRACT_ID_BYTES];
+            bytes.copy_from_slice(
+                &buf[i * CONTRACT_ID_BYTES..(i + 1) * CONTRACT_ID_BYTES],
+            );
+            v.push(ContractId::from_bytes(bytes));
+        }
+        v
+    })
 }
 
 /// Returns the gas limit with which the contact was called.

--- a/piecrust/Cargo.toml
+++ b/piecrust/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.26.1-rc.3"
+version = "0.27.0-rc.0"
 
 edition = "2021"
 license = "MPL-2.0"

--- a/piecrust/Cargo.toml
+++ b/piecrust/Cargo.toml
@@ -14,7 +14,7 @@ license = "MPL-2.0"
 
 [dependencies]
 crumbles = { version = "0.3", path = "../crumbles" }
-piecrust-uplink = { version = "0.17", path = "../piecrust-uplink" }
+piecrust-uplink = { version = "0.17.2-rc.0", path = "../piecrust-uplink" }
 
 dusk-wasmtime = { version = "21.0.0-alpha", default-features = false, features = ["cranelift", "runtime", "parallel-compilation"] }
 bytecheck = "0.6"

--- a/piecrust/src/call_tree.rs
+++ b/piecrust/src/call_tree.rs
@@ -101,6 +101,20 @@ impl CallTree {
         current.map(|inner| unsafe { (*inner).elem })
     }
 
+    /// Returns all call ids.
+    pub(crate) fn call_ids(&self) -> Vec<&ContractId> {
+        let mut v = Vec::new();
+        let mut current = self.0;
+
+        while current.is_some() {
+            let p = *current.as_ref().unwrap();
+            v.push(unsafe { &(*p).elem.contract_id });
+            current = current.and_then(|inner| unsafe { (*inner).parent });
+        }
+
+        v
+    }
+
     /// Clears the call tree of all elements.
     pub(crate) fn clear(&mut self) {
         unsafe {

--- a/piecrust/src/imports.rs
+++ b/piecrust/src/imports.rs
@@ -392,10 +392,10 @@ fn callstack(env: Caller<Env>) -> i32 {
     let instance = env.self_instance();
 
     let mut i = 0usize;
-    for contract_id in env.callstack_iter() {
+    while let Some(element) = env.nth_from_top(i) {
         instance.with_arg_buf_mut(|buf| {
             buf[i * CONTRACT_ID_BYTES..(i + 1) * CONTRACT_ID_BYTES]
-                .copy_from_slice(contract_id.as_bytes());
+                .copy_from_slice(element.contract_id.as_bytes());
         });
         i += 1;
     }

--- a/piecrust/src/imports.rs
+++ b/piecrust/src/imports.rs
@@ -392,10 +392,10 @@ fn callstack(env: Caller<Env>) -> i32 {
     let instance = env.self_instance();
 
     let mut i = 0usize;
-    while let Some(element) = env.nth_from_top(i) {
+    for contract_id in env.call_ids() {
         instance.with_arg_buf_mut(|buf| {
             buf[i * CONTRACT_ID_BYTES..(i + 1) * CONTRACT_ID_BYTES]
-                .copy_from_slice(element.contract_id.as_bytes());
+                .copy_from_slice(contract_id.as_bytes());
         });
         i += 1;
     }

--- a/piecrust/src/session.rs
+++ b/piecrust/src/session.rs
@@ -643,6 +643,10 @@ impl Session {
         self.inner.call_tree.nth_parent(n)
     }
 
+    pub(crate) fn call_ids(&self) -> Vec<&ContractId> {
+        self.inner.call_tree.call_ids()
+    }
+
     /// Creates a new instance of the given contract, returning its memory
     /// length.
     fn create_instance(

--- a/piecrust/src/session.rs
+++ b/piecrust/src/session.rs
@@ -643,10 +643,6 @@ impl Session {
         self.inner.call_tree.nth_parent(n)
     }
 
-    pub(crate) fn callstack_iter(&self) -> impl Iterator<Item = &ContractId> {
-        self.inner.call_tree.iter().map(|elem| &elem.contract_id)
-    }
-
     /// Creates a new instance of the given contract, returning its memory
     /// length.
     fn create_instance(

--- a/piecrust/src/session.rs
+++ b/piecrust/src/session.rs
@@ -643,6 +643,10 @@ impl Session {
         self.inner.call_tree.nth_parent(n)
     }
 
+    pub(crate) fn callstack_iter(&self) -> impl Iterator<Item = &ContractId> {
+        self.inner.call_tree.iter().map(|elem| &elem.contract_id)
+    }
+
     /// Creates a new instance of the given contract, returning its memory
     /// length.
     fn create_instance(

--- a/piecrust/tests/callcenter.rs
+++ b/piecrust/tests/callcenter.rs
@@ -243,6 +243,30 @@ pub fn cc_caller_uninit() -> Result<(), Error> {
 }
 
 #[test]
+pub fn cc_callstack() -> Result<(), Error> {
+    let vm = VM::ephemeral()?;
+
+    let mut session = vm.session(SessionData::builder())?;
+
+    let center_id = session.deploy(
+        contract_bytecode!("callcenter"),
+        ContractData::builder().owner(OWNER),
+        LIMIT,
+    )?;
+
+    let callstack: Vec<ContractId> = session
+        .call(center_id, "return_callstack", &(), LIMIT)?
+        .data;
+    assert_eq!(callstack.len(), 1);
+
+    let self_id: ContractId =
+        session.call(center_id, "return_self_id", &(), LIMIT)?.data;
+    assert_eq!(callstack[0], self_id);
+
+    Ok(())
+}
+
+#[test]
 pub fn cc_self_id() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
 

--- a/piecrust/tests/callcenter.rs
+++ b/piecrust/tests/callcenter.rs
@@ -263,6 +263,15 @@ pub fn cc_callstack() -> Result<(), Error> {
         session.call(center_id, "return_self_id", &(), LIMIT)?.data;
     assert_eq!(callstack[0], self_id);
 
+    const N: u32 = 5;
+    let callstack: Vec<ContractId> = session
+        .call(center_id, "call_self_n_times", &N, LIMIT)?
+        .data;
+    assert_eq!(callstack.len(), N as usize + 1);
+    for i in 1..=N as usize {
+        assert_eq!(callstack[0], callstack[i]);
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
Store merkle positions in binary rather than using rkyv.
This has the advantage of better and more stable performance, as well as
making the disk format explicit and not dependent on rkyv, hence easier
to maintain in the future.

Implements issue #410 
