### PR TITLE
uplink: bump version to `0.17.2`

### DIFF
--- a/piecrust-uplink/CHANGELOG.md
+++ b/piecrust-uplink/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.2] - 2024-12-17
+
 ### Added
 
 - Add serde `Serialize` and `Deserialize` implementations for `ContractId` and `Event` [#414]
@@ -248,7 +250,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#136]: https://github.com/dusk-network/piecrust/issues/136
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/uplink-0.17.1...HEAD
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/uplink-0.17.2...HEAD
+[0.17.2]: https://github.com/dusk-network/piecrust/compare/uplink-0.17.1...uplink-0.17.2
 [0.17.1]: https://github.com/dusk-network/piecrust/compare/uplink-0.17.0...uplink-0.17.1
 [0.17.0]: https://github.com/dusk-network/piecrust/compare/uplink-0.16.0...uplink-0.17.0
 [0.16.0]: https://github.com/dusk-network/piecrust/compare/uplink-0.15.0...uplink-0.16.0

--- a/piecrust-uplink/Cargo.toml
+++ b/piecrust-uplink/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.17.1"
+version = "0.17.2"
 
 edition = "2021"
 license = "MPL-2.0"


### PR DESCRIPTION
## [0.17.2] - 2024-12-17

### Added

- Add serde `Serialize` and `Deserialize` implementations for `ContractId` and `Event` [#414]
- Add `serde`, `hex`, `base64` and `serde_json` optional dependencies [#414]
- Add `serde` feature [#414]

[0.17.2]: https://github.com/dusk-network/piecrust/compare/uplink-0.17.1...uplink-0.17.2