### PR TITLE
callstack returns callers id list without self id

### DIFF
--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Change `callstack` to return callers' id list with no self id at the beginning [#422]
+
 ## [0.27.1] - 2025-01-15
 
 ### Added
@@ -493,6 +495,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- ISSUES -->
 
 [#rusk_3341]: https://github.com/dusk-network/rusk/issues/3341
+[#422]: https://github.com/dusk-network/piecrust/issues/422
 [#410]: https://github.com/dusk-network/piecrust/issues/410
 [#405]: https://github.com/dusk-network/piecrust/issues/405
 [#396]: https://github.com/dusk-network/piecrust/issues/396

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
 - Change `callstack` to return callers' id list with no self id at the beginning [#422]
 
 ## [0.27.1] - 2025-01-15

--- a/piecrust/src/imports.rs
+++ b/piecrust/src/imports.rs
@@ -392,7 +392,7 @@ fn callstack(env: Caller<Env>) -> i32 {
     let instance = env.self_instance();
 
     let mut i = 0usize;
-    for contract_id in env.call_ids() {
+    for contract_id in env.call_ids().iter().skip(1) {
         instance.with_arg_buf_mut(|buf| {
             buf[i * CONTRACT_ID_BYTES..(i + 1) * CONTRACT_ID_BYTES]
                 .copy_from_slice(contract_id.as_bytes());

--- a/piecrust/tests/callcenter.rs
+++ b/piecrust/tests/callcenter.rs
@@ -263,19 +263,18 @@ pub fn cc_callstack() -> Result<(), Error> {
     let callstack: Vec<ContractId> = session
         .call(center_id, "return_callstack", &(), LIMIT)?
         .data;
-    assert_eq!(callstack.len(), 1);
+    assert_eq!(callstack.len(), 0);
 
     let self_id: ContractId =
         session.call(center_id, "return_self_id", &(), LIMIT)?.data;
-    assert_eq!(callstack[0], self_id);
 
     const N: u32 = 5;
     let callstack: Vec<ContractId> = session
         .call(center_id, "call_self_n_times", &N, LIMIT)?
         .data;
-    assert_eq!(callstack.len(), N as usize + 1);
-    for i in 1..=N as usize {
-        assert_eq!(callstack[0], callstack[i]);
+    assert_eq!(callstack.len(), N as usize);
+    for i in 0..N as usize {
+        assert_eq!(self_id, callstack[i]);
     }
 
     let res = session
@@ -295,9 +294,8 @@ pub fn cc_callstack() -> Result<(), Error> {
     let callstack: Vec<ContractId> =
         rkyv::from_bytes(&res).expect("Deserialization to succeed");
 
-    assert_eq!(callstack.len(), 2);
-    assert_eq!(callstack[0], callstack_id);
-    assert_eq!(callstack[1], center_id);
+    assert_eq!(callstack.len(), 1);
+    assert_eq!(callstack[0], center_id);
 
     Ok(())
 }


### PR DESCRIPTION
Callstack returns callers id list without self id.

Implements issue #422
