### PR TITLE
Upgrade toolchain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 help: ## Display this help screen
 	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
 
-COMPILER_VERSION=v0.2.0
+COMPILER_VERSION=v0.3.0-rc
 
 setup-compiler: ## Setup the Dusk Contract Compiler
 	@./scripts/setup-compiler.sh $(COMPILER_VERSION)

--- a/crumbles/src/lib.rs
+++ b/crumbles/src/lib.rs
@@ -390,7 +390,7 @@ where
 
 #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
 fn system_page_size() -> usize {
-    static mut PAGE_SIZE: OnceLock<usize> = OnceLock::new();
+    static PAGE_SIZE: OnceLock<usize> = OnceLock::new();
     unsafe {
         *PAGE_SIZE.get_or_init(|| libc::sysconf(libc::_SC_PAGESIZE) as usize)
     }

--- a/piecrust-uplink/src/abi/handlers.rs
+++ b/piecrust-uplink/src/abi/handlers.rs
@@ -17,11 +17,10 @@ unsafe fn handle_panic(info: &PanicInfo) -> ! {
 
     // If we fail in writing to the argument buffer, we just call `panic` after
     // writing a standard message instead.
-    if let Some(args) = info.message() {
-        if w.write_fmt(*args).is_err() {
-            w = crate::ArgbufWriter::default();
-            let _ = write!(w, "PANIC INFO TOO LONG");
-        }
+
+    if w.write_fmt(format_args!("{}", info.message())).is_err() {
+        w = crate::ArgbufWriter::default();
+        let _ = write!(w, "PANIC INFO TOO LONG");
     }
 
     panic(w.ofs() as u32);

--- a/piecrust-uplink/src/lib.rs
+++ b/piecrust-uplink/src/lib.rs
@@ -60,7 +60,7 @@
 //! [externs]: https://github.com/dusk-network/piecrust/blob/c2dadaa8dec210bdbbc72619a687eb8c6f693877/piecrust-uplink/src/abi/state.rs#L42-L64
 
 #![allow(internal_features)]
-#![feature(lang_items, panic_info_message)]
+#![feature(lang_items)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![no_std]
 

--- a/piecrust/src/session.rs
+++ b/piecrust/src/session.rs
@@ -334,9 +334,8 @@ impl Session {
             Ok(())
         };
 
-        instantiate().map_err(|err| {
+        instantiate().inspect_err(|_| {
             self.inner.contract_session.remove_contract(&contract_id);
-            err
         })
     }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2024-10-13"
+channel = "nightly-2024-07-30"
 targets = ["wasm32-unknown-unknown"]
 components = ["rust-src", "rustfmt", "cargo", "clippy"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2023-11-10"
+channel = "nightly-2024-10-13"
 targets = ["wasm32-unknown-unknown"]
 components = ["rust-src", "rustfmt", "cargo", "clippy"]


### PR DESCRIPTION
For https://github.com/dusk-network/rusk/issues/3470.

The rust version chosen is a 1.82.0 nightly (2024-07-30) because it uses LLVM 18. From LLVM 19, the reference-types feature is enabled by default, and I thought it would be a good idea to pick a toolchain that will require the least amount of changes.