### PR TITLE
blocking 'init' method to be called only during deployment

### DIFF
--- a/contracts/callcenter/src/lib.rs
+++ b/contracts/callcenter/src/lib.rs
@@ -34,6 +34,11 @@ impl Callcenter {
         uplink::call(counter_id, "increment", &()).unwrap()
     }
 
+    /// Call specified contract's init method with an empty argument
+    pub fn call_init(&mut self, contract_id: ContractId) {
+        uplink::call(contract_id, "init", &()).unwrap()
+    }
+
     /// Query a contract specified by its ID
     pub fn delegate_query(
         &self,
@@ -101,7 +106,7 @@ impl Callcenter {
         match n {
             0 => uplink::callstack(),
             _ => uplink::call(self_id, "call_self_n_times", &(n - 1))
-                .expect("calling self should succeed")
+                .expect("calling self should succeed"),
         }
     }
 
@@ -134,6 +139,14 @@ unsafe fn query_counter(arg_len: u32) -> u32 {
 #[no_mangle]
 unsafe fn increment_counter(arg_len: u32) -> u32 {
     wrap_call(arg_len, |counter_id| STATE.increment_counter(counter_id))
+}
+
+/// Expose `Callcenter::call_init()` to the host
+#[no_mangle]
+unsafe fn call_init(arg_len: u32) -> u32 {
+    wrap_call(arg_len, |contract_id| {
+        STATE.call_init(contract_id)
+    })
 }
 
 /// Expose `Callcenter::calling_self()` to the host

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added blocking 'init' method to be called only during deployment [#433]
+
 ## [0.27.2] - 2025-02-20
 
 ### Changed
@@ -499,6 +503,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- ISSUES -->
 
 [#rusk_3341]: https://github.com/dusk-network/rusk/issues/3341
+[#433]: https://github.com/dusk-network/piecrust/issues/433
 [#422]: https://github.com/dusk-network/piecrust/issues/422
 [#410]: https://github.com/dusk-network/piecrust/issues/410
 [#405]: https://github.com/dusk-network/piecrust/issues/405

--- a/piecrust/src/imports.rs
+++ b/piecrust/src/imports.rs
@@ -20,6 +20,7 @@ use piecrust_uplink::{
 
 use crate::config::BYTE_STORE_COST;
 use crate::instance::{Env, WrappedInstance};
+use crate::session::INIT_METHOD;
 use crate::Error;
 
 pub const GAS_PASS_PCT: u64 = 93;
@@ -277,6 +278,11 @@ pub(crate) fn c(
 
         let name = core::str::from_utf8(&memory[name_ofs..][..name_len])
             .map_err(|e| WithMemoryError::AfterPush(e.into()))?;
+        if name == INIT_METHOD {
+            return Err(WithMemoryError::AfterPush(Error::InitalizationError(
+                "init call not allowed".into(),
+            )));
+        }
 
         let arg = &arg_buf[..arg_len as usize];
 

--- a/piecrust/tests/initializer.rs
+++ b/piecrust/tests/initializer.rs
@@ -40,12 +40,6 @@ fn init() -> Result<(), Error> {
         result.is_err(),
         "calling init directly as transaction should not be allowed"
     );
-    // we should not be able to call init as query neither
-    let result = session.call::<u8, ()>(id, CONTRACT_INIT_METHOD, &0xaa, LIMIT);
-    assert!(
-        result.is_err(),
-        "calling init directly as query should not be allowed"
-    );
 
     // make sure the state is still ok
     assert_eq!(
@@ -67,6 +61,39 @@ fn init() -> Result<(), Error> {
     assert!(
         result.is_err(),
         "calling init directly should never be allowed"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn init_indirect_call_blocked() -> Result<(), Error> {
+    let vm = VM::ephemeral()?;
+
+    let mut session = vm.session(SessionData::builder())?;
+
+    let empty_initializer_contract_id = session.deploy(
+        contract_bytecode!("empty_initializer"),
+        ContractData::builder().owner(OWNER),
+        LIMIT,
+    )?;
+
+    let callcenter_contract_id = session.deploy(
+        contract_bytecode!("callcenter"),
+        ContractData::builder().owner(OWNER),
+        LIMIT,
+    )?;
+
+    let result = session.call::<_, ()>(
+        callcenter_contract_id,
+        "call_init",
+        &empty_initializer_contract_id,
+        LIMIT,
+    );
+
+    assert!(
+        result.is_err(),
+        "calling init indirectly should not be allowed"
     );
 
     Ok(())


### PR DESCRIPTION
Functionality and test for blocking 'init' method to be called only during deployment.

Implements issue #433 

It will have a companion test in Rusk as well.