### PR TITLE
piecrust: version 0.28.0

### DIFF
--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.0] - 2025-03-19
+
 - Further improvement commit operations' performance [#396], [#419]
 
 ### Added
@@ -559,7 +561,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- VERSIONS -->
 
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/piecrust-0.27.2...HEAD
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/piecrust-0.28.0...HEAD
+[0.28.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.27.2...piecrust-0.28.0
 [0.27.2]: https://github.com/dusk-network/piecrust/compare/piecrust-0.27.1...piecrust-0.27.2
 [0.27.1]: https://github.com/dusk-network/piecrust/compare/piecrust-0.27.0...piecrust-0.27.1
 [0.27.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.26.0...piecrust-0.27.0

--- a/piecrust/Cargo.toml
+++ b/piecrust/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.28.0-rc.6"
+version = "0.28.0"
 
 edition = "2021"
 license = "MPL-2.0"


### PR DESCRIPTION
piecrust: version 0.28.0

contains:
performance improvements (including index file elimination)
init function fix
addresses: #396, #419, #433