### PR TITLE
piecrust: commit-specific storage for bytecodes

### DIFF
--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Enriched commit-specific storage to support contract bytecodes [#450]
 - Added blocking 'init' method to be called only during deployment [#433]
 
 ## [0.27.2] - 2025-02-20
@@ -518,6 +519,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- ISSUES -->
 
+[#450]: https://github.com/dusk-network/piecrust/issues/450
 [#rusk_3470]: https://github.com/dusk-network/rusk/issues/3470
 [#rusk_3341]: https://github.com/dusk-network/rusk/issues/3341
 [#440]: https://github.com/dusk-network/piecrust/issues/440

--- a/piecrust/Cargo.toml
+++ b/piecrust/Cargo.toml
@@ -28,6 +28,7 @@ hex = "0.4"
 dusk-merkle = { version = "0.5", features = ["rkyv-impl"] }
 const-decoder = "0.3"
 tracing = "0.1.40"
+indexmap = "=2.11.4"
 
 [dev-dependencies]
 once_cell = "1.18"

--- a/piecrust/src/store/commit/finalizer.rs
+++ b/piecrust/src/store/commit/finalizer.rs
@@ -7,8 +7,8 @@
 use crate::store::baseinfo::BaseInfo;
 use crate::store::hasher::Hash;
 use crate::store::{
-    BASE_FILE, ELEMENT_FILE, LEAF_DIR, MAIN_DIR, MEMORY_DIR, TREE_POS_FILE,
-    TREE_POS_OPT_FILE,
+    BASE_FILE, BYTECODE_DIR, ELEMENT_FILE, LEAF_DIR, MAIN_DIR, MEMORY_DIR,
+    METADATA_EXTENSION, OBJECTCODE_EXTENSION, TREE_POS_FILE, TREE_POS_OPT_FILE,
 };
 use std::path::Path;
 use std::{fs, io};
@@ -26,6 +26,27 @@ impl CommitFinalizer {
         let base_info = BaseInfo::from_path(&base_info_path)?;
         for contract_hint in base_info.contract_hints {
             let contract_hex = hex::encode(contract_hint);
+            // BYTECODE
+            let bytecode_src_dir = main_dir.join(BYTECODE_DIR).join(&root);
+            let bytecode_src_path = bytecode_src_dir.join(&contract_hex);
+            let module_src_path =
+                bytecode_src_path.with_extension(OBJECTCODE_EXTENSION);
+            let metadata_src_path =
+                bytecode_src_path.with_extension(METADATA_EXTENSION);
+            let bytecode_dst_path =
+                main_dir.join(BYTECODE_DIR).join(&contract_hex);
+            let module_dst_path =
+                bytecode_dst_path.with_extension(OBJECTCODE_EXTENSION);
+            let metadata_dst_path =
+                bytecode_dst_path.with_extension(METADATA_EXTENSION);
+            if bytecode_src_path.is_file()
+                && module_src_path.is_file()
+                && metadata_src_path.is_file()
+            {
+                fs::rename(&bytecode_src_path, bytecode_dst_path)?;
+                fs::rename(&module_src_path, module_dst_path)?;
+                fs::rename(&metadata_src_path, metadata_dst_path)?;
+            }
             // MEMORY
             let src_path =
                 main_dir.join(MEMORY_DIR).join(&contract_hex).join(&root);

--- a/piecrust/src/store/commit/reader.rs
+++ b/piecrust/src/store/commit/reader.rs
@@ -121,7 +121,11 @@ impl CommitReader {
 
             // Check that all contracts in the index file have a corresponding
             // bytecode and memory pages specified.
-            let bytecode_path = bytecode_dir.join(&contract_hex);
+            let bytecode_path = commit_id
+                .as_ref()
+                .map(|cid| bytecode_dir.join(cid).join(&contract_hex))
+                .filter(|p| p.is_file())
+                .unwrap_or(bytecode_dir.join(&contract_hex));
             if !bytecode_path.is_file() {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,

--- a/piecrust/src/store/session.rs
+++ b/piecrust/src/store/session.rs
@@ -297,8 +297,21 @@ impl ContractSession {
 
                             let contract_hex = hex::encode(contract);
 
-                            let bytecode_path =
-                                base_dir.join(BYTECODE_DIR).join(&contract_hex);
+                            let bytecode_path = commit_id
+                                .as_ref()
+                                .map(|hash| {
+                                    base_dir
+                                        .join(BYTECODE_DIR)
+                                        .join(hex::encode(hash.as_bytes()))
+                                        .join(&contract_hex)
+                                })
+                                .filter(|p| p.is_file())
+                                .unwrap_or(
+                                    base_dir
+                                        .join(BYTECODE_DIR)
+                                        .join(&contract_hex),
+                                );
+
                             let module_path = bytecode_path
                                 .with_extension(OBJECTCODE_EXTENSION);
                             let metadata_path = bytecode_path


### PR DESCRIPTION
piecrust: commit-specific storage for contract bytecodes, modules and metadata files

implements issue #450 

solves problem in Rusk issue #3898
