### PR TITLE
Expose caller stack to call hooks

### DIFF
--- a/piecrust-uplink/src/abi/state.rs
+++ b/piecrust-uplink/src/abi/state.rs
@@ -339,7 +339,11 @@ pub fn caller() -> Option<ContractId> {
     }
 }
 
-/// Returns IDs of all calling contracts present in the calling stack
+/// Returns IDs of all calling contracts present in the calling stack.
+///
+/// The current contract is not included. Index 0 is the immediate caller, and
+/// the last element is the root contract call. Direct/root calls return an
+/// empty stack.
 pub fn callstack() -> Vec<ContractId> {
     let n = unsafe { ext::callstack() };
     with_arg_buf(|buf| {

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Expose the active caller stack to call hooks before each inter-contract call.
+
 ## [0.31.0] - 2026-06-12
 
 ### Added

--- a/piecrust/src/session.rs
+++ b/piecrust/src/session.rs
@@ -93,6 +93,10 @@ impl Drop for Session {
 /// Receives the callee contract ID, the function name, the raw argument bytes,
 /// and the current call stack before the callee is pushed. Returns `Ok(())` to
 /// allow the call, or `Err(reason)` to reject it with a descriptive message.
+///
+/// The callee is not included in the stack because the hook runs before the
+/// callee is pushed. The stack is ordered like `abi::callstack()`: index 0 is
+/// the immediate caller, and the last element is the root contract call.
 #[cfg(feature = "call-hook")]
 pub type CallHook = Box<
     dyn Fn(&ContractId, &str, &[u8], &[&ContractId]) -> Result<(), String>

--- a/piecrust/src/session.rs
+++ b/piecrust/src/session.rs
@@ -90,12 +90,15 @@ impl Drop for Session {
 
 /// A hook called before each inter-contract call.
 ///
-/// Receives the callee contract ID, the function name, and the raw argument
-/// bytes. Returns `Ok(())` to allow the call, or `Err(reason)` to reject it
-/// with a descriptive message.
+/// Receives the callee contract ID, the function name, the raw argument bytes,
+/// and the current call stack before the callee is pushed. Returns `Ok(())` to
+/// allow the call, or `Err(reason)` to reject it with a descriptive message.
 #[cfg(feature = "call-hook")]
-pub type CallHook =
-    Box<dyn Fn(&ContractId, &str, &[u8]) -> Result<(), String> + Send + Sync>;
+pub type CallHook = Box<
+    dyn Fn(&ContractId, &str, &[u8], &[&ContractId]) -> Result<(), String>
+        + Send
+        + Sync,
+>;
 
 struct SessionInner {
     current: ContractId,
@@ -992,8 +995,8 @@ impl Session {
 
     /// Set a hook that is called before each inter-contract call.
     ///
-    /// The hook receives the callee contract ID, the function name, and the
-    /// raw argument bytes.
+    /// The hook receives the callee contract ID, the function name, the raw
+    /// argument bytes, and the current call stack before the callee is pushed.
     #[cfg(feature = "call-hook")]
     pub fn set_call_hook(&mut self, hook: CallHook) -> Option<CallHook> {
         self.inner_mut().call_hook.replace(hook)
@@ -1017,7 +1020,8 @@ impl Session {
         arg: &[u8],
     ) -> Result<(), String> {
         if let Some(hook) = &self.inner().call_hook {
-            hook(callee, fn_name, arg)
+            let call_stack = self.call_ids();
+            hook(callee, fn_name, arg, &call_stack)
         } else {
             Ok(())
         }

--- a/piecrust/tests/call_hook.rs
+++ b/piecrust/tests/call_hook.rs
@@ -9,7 +9,7 @@ use std::sync::{Arc, Mutex};
 use piecrust::{
     CallHook, ContractData, Error, SessionData, VM, contract_bytecode,
 };
-use piecrust_uplink::ContractId;
+use piecrust_uplink::{ContractError, ContractId};
 
 const OWNER: [u8; 32] = [0u8; 32];
 const LIMIT: u64 = 1_000_000;
@@ -184,6 +184,71 @@ fn call_hook_can_deserialize_fn_args() -> Result<(), Error> {
         assert_eq!(call.call_stack.len(), i + 1);
         assert!(call.call_stack.iter().all(|id| *id == center_id));
     }
+
+    Ok(())
+}
+
+#[test]
+fn call_hook_stack_is_immediate_caller_first() -> Result<(), Error> {
+    let vm = VM::ephemeral()?;
+    let mut session = vm.session(SessionData::builder())?;
+
+    let (counter_id, _) = session.deploy::<_, (), _>(
+        contract_bytecode!("counter"),
+        ContractData::builder().owner(OWNER),
+        LIMIT,
+    )?;
+    let outer_id = ContractId::from_bytes([0x11; 32]);
+    let (outer_id, _) = session.deploy::<_, (), _>(
+        contract_bytecode!("callcenter"),
+        ContractData::builder().owner(OWNER).contract_id(outer_id),
+        LIMIT,
+    )?;
+    let inner_id = ContractId::from_bytes([0x22; 32]);
+    let (inner_id, _) = session.deploy::<_, (), _>(
+        contract_bytecode!("callcenter"),
+        ContractData::builder().owner(OWNER).contract_id(inner_id),
+        LIMIT,
+    )?;
+
+    let inner_args = rkyv::to_bytes::<_, 1024>(&(
+        counter_id,
+        String::from("read_value"),
+        Vec::<u8>::new(),
+    ))
+    .expect("inner args should serialize")
+    .to_vec();
+
+    let recorder = CallRecorder::new();
+    session.set_call_hook(recorder.hook());
+
+    let res = session
+        .call::<_, Result<Vec<u8>, ContractError>>(
+            outer_id,
+            "delegate_query",
+            &(inner_id, String::from("delegate_query"), inner_args),
+            LIMIT,
+        )?
+        .data
+        .expect("nested ICC should succeed");
+    let inner_res: Result<Vec<u8>, ContractError> =
+        rkyv::from_bytes(&res).expect("inner result should decode");
+    let value: i64 = rkyv::from_bytes(
+        &inner_res.expect("inner counter query should succeed"),
+    )
+    .expect("counter value should decode");
+    assert_eq!(value, 0xfc);
+
+    let calls = recorder.calls();
+    assert_eq!(calls.len(), 2);
+
+    assert_eq!(calls[0].contract, inner_id);
+    assert_eq!(calls[0].fn_name, "delegate_query");
+    assert_eq!(calls[0].call_stack, vec![outer_id]);
+
+    assert_eq!(calls[1].contract, counter_id);
+    assert_eq!(calls[1].fn_name, "read_value");
+    assert_eq!(calls[1].call_stack, vec![inner_id, outer_id]);
 
     Ok(())
 }

--- a/piecrust/tests/call_hook.rs
+++ b/piecrust/tests/call_hook.rs
@@ -20,6 +20,7 @@ struct ContractCall {
     contract: ContractId,
     fn_name: String,
     fn_args: Vec<u8>,
+    call_stack: Vec<ContractId>,
 }
 
 /// Records all inter-contract calls observed by a call hook.
@@ -33,11 +34,12 @@ impl CallRecorder {
 
     fn hook(&self) -> CallHook {
         let inner = self.0.clone();
-        Box::new(move |contract, fn_name, fn_args| {
+        Box::new(move |contract, fn_name, fn_args, call_stack| {
             inner.lock().unwrap().push(ContractCall {
                 contract: *contract,
                 fn_name: fn_name.to_owned(),
                 fn_args: fn_args.to_vec(),
+                call_stack: call_stack.iter().map(|id| **id).collect(),
             });
             Ok(())
         })
@@ -77,6 +79,7 @@ fn call_hook_observes_inter_contract_call() -> Result<(), Error> {
     assert_eq!(calls.len(), 1);
     assert_eq!(calls[0].contract, counter_id);
     assert_eq!(calls[0].fn_name, "read_value");
+    assert_eq!(calls[0].call_stack, vec![center_id]);
 
     Ok(())
 }
@@ -140,6 +143,7 @@ fn call_hook_observes_multiple_iccs() -> Result<(), Error> {
 
     for call in &calls {
         assert_eq!(call.contract, counter_id);
+        assert_eq!(call.call_stack, vec![center_id]);
     }
 
     Ok(())
@@ -177,6 +181,8 @@ fn call_hook_can_deserialize_fn_args() -> Result<(), Error> {
         let arg: u32 = rkyv::from_bytes(&call.fn_args)
             .expect("fn_args should deserialize as u32");
         assert_eq!(arg, 2 - i as u32);
+        assert_eq!(call.call_stack.len(), i + 1);
+        assert!(call.call_stack.iter().all(|id| *id == center_id));
     }
 
     Ok(())
@@ -204,7 +210,7 @@ fn call_hook_can_reject_call() -> Result<(), Error> {
 
     // Set a hook that rejects calls to the counter's "increment" function
     let reject_id = counter_id;
-    session.set_call_hook(Box::new(move |contract, fn_name, _| {
+    session.set_call_hook(Box::new(move |contract, fn_name, _, _| {
         if *contract == reject_id && fn_name == "increment" {
             Err("increment rejected by test hook".into())
         } else {
@@ -263,11 +269,12 @@ fn set_and_clear_call_hook_return_previous_hook() -> Result<(), Error> {
     let mut session = vm.session(SessionData::builder())?;
 
     // No hook set initially — set_call_hook should return None
-    let prev = session.set_call_hook(Box::new(|_, _, _| Ok(())));
+    let prev = session.set_call_hook(Box::new(|_, _, _, _| Ok(())));
     assert!(prev.is_none(), "first set should return None");
 
     // Replacing the hook should return the previous one
-    let prev = session.set_call_hook(Box::new(|_, _, _| Err("reject".into())));
+    let prev =
+        session.set_call_hook(Box::new(|_, _, _, _| Err("reject".into())));
     assert!(prev.is_some(), "second set should return the previous hook");
 
     // Clearing should return the current hook
@@ -298,7 +305,7 @@ fn clear_call_hook_allows_previously_rejected_call() -> Result<(), Error> {
     )?;
 
     // Set a hook that rejects all inter-contract calls
-    session.set_call_hook(Box::new(|_, _, _| Err("rejected".into())));
+    session.set_call_hook(Box::new(|_, _, _, _| Err("rejected".into())));
 
     // Verify the hook rejects
     let result =


### PR DESCRIPTION
## Summary

- Pass the active caller stack to call hooks before each inter-contract call.
- Keep the stack borrowed as `&[&ContractId]` so hook callers do not copy contract IDs.
- Extend call-hook tests to assert the observed stack for direct and recursive inter-contract calls.
- Document the call-hook API change in the changelog.

## Validation

- `make test`
