### PR TITLE
Release Piecrust 0.32.0

### DIFF
--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.32.0] - 2026-06-19
+
 ### Changed
 
 - Expose the active caller stack to call hooks before each inter-contract call.
@@ -619,7 +621,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- VERSIONS -->
 
-[Unreleased]: https://github.com/dusk-network/piecrust/compare/piecrust-0.31.0...HEAD
+[Unreleased]: https://github.com/dusk-network/piecrust/compare/piecrust-0.32.0...HEAD
+[0.32.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.31.0...piecrust-0.32.0
 [0.31.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.30.0...piecrust-0.31.0
 [0.30.0]: https://github.com/dusk-network/piecrust/compare/piecrust-0.28.1...piecrust-0.30.0
 [0.28.1]: https://github.com/dusk-network/piecrust/compare/piecrust-0.28.0...piecrust-0.28.1

--- a/piecrust/Cargo.toml
+++ b/piecrust/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["wasm", "no-std", "cryptography::cryptocurrencies"]
 keywords = ["virtual", "machine", "smart", "contract", "wasm"]
 
 repository = "https://github.com/dusk-network/piecrust"
-version = "0.31.0"
+version = "0.32.0"
 
 edition.workspace = true
 license = "MPL-2.0"


### PR DESCRIPTION
## Summary

- Bump the `piecrust` crate to `0.32.0`.
- Move the call-hook stack context changelog entry into the `0.32.0` release section.
- Update Piecrust changelog compare links for the new release tag.

## Notes

`piecrust-uplink` is intentionally left at `0.21.0`; the uplink change in the preceding PR was documentation-only and is not needed for Rusk to consume the new `piecrust` API.

## Verification

- `make fmt`