### PR TITLE
Contain host query panics

### DIFF
--- a/contracts/host/src/lib.rs
+++ b/contracts/host/src/lib.rs
@@ -15,6 +15,7 @@ use alloc::vec::Vec;
 
 use piecrust_uplink as uplink;
 use dusk_plonk::prelude::*;
+use uplink::{ContractError, ContractId};
 
 /// Struct that describes the state of the host contract
 pub struct Hoster;
@@ -49,6 +50,14 @@ impl Hoster {
     pub fn host_very_expensive(&self) {
         uplink::host_query::<_, ()>("very_expensive", ());
     }
+
+    /// Call another host test contract's 'host_very_expensive' function.
+    pub fn delegate_host_very_expensive(
+        &self,
+        contract: ContractId,
+    ) -> Result<(), ContractError> {
+        uplink::call(contract, "host_very_expensive", &())
+    }
 }
 
 /// Expose `Hoster::host_hash()` to the host
@@ -77,6 +86,16 @@ unsafe fn host_very_expensive(arg_len: u32) -> u32 {
     unsafe {
         uplink::wrap_call(arg_len, |_: ()| {
             (*&raw const STATE).host_very_expensive()
+        })
+    }
+}
+
+/// Expose `Hoster::delegate_host_very_expensive()` to the host
+#[unsafe(no_mangle)]
+unsafe fn delegate_host_very_expensive(arg_len: u32) -> u32 {
+    unsafe {
+        uplink::wrap_call(arg_len, |contract| {
+            (*&raw const STATE).delegate_host_very_expensive(contract)
         })
     }
 }

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `SessionDataBuilder::contain_hq_panics` opt-out for callers that need host-query panics to propagate [#476]
+
+### Changed
+
+- Contain host-query panics by default and return them as contract panic errors [#476]
+
 ## [0.32.0] - 2026-06-19
 
 ### Changed
@@ -564,6 +572,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- ISSUES -->
 [#466]: https://github.com/dusk-network/piecrust/issues/466
+[#476]: https://github.com/dusk-network/piecrust/issues/476
 
 [#rusk_3341]: https://github.com/dusk-network/rusk/issues/3341
 [#440]: https://github.com/dusk-network/piecrust/issues/440

--- a/piecrust/src/imports.rs
+++ b/piecrust/src/imports.rs
@@ -8,6 +8,7 @@ mod wasm32;
 mod wasm64;
 
 use std::any::Any;
+use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::Arc;
 
 use dusk_wasmtime::{
@@ -24,6 +25,7 @@ use crate::instance::{Env, WrappedInstance};
 use crate::session::INIT_METHOD;
 
 pub const GAS_PASS_PCT: u64 = 93;
+const HOST_QUERY_PANICKED: &str = "host query panicked";
 
 pub(crate) struct Imports;
 
@@ -176,14 +178,18 @@ pub(crate) fn hq(
         .host_query_arc(&name)
         .ok_or_else(move || Error::MissingHostQuery(name))?;
     let mut query_arg: Box<dyn Any> = Box::new(());
+    let contain_hq_panics = env.contain_hq_panics();
     let query_cost = {
         let instance = env.self_instance();
-        instance.with_arg_buf(|arg_buf| {
-            host_query.deserialize_and_price(
-                &arg_buf[..arg_len as usize],
-                &mut query_arg,
-            )
-        })
+        let result = instance.with_arg_buf(|arg_buf| {
+            maybe_contain_hq_panic(contain_hq_panics, || {
+                host_query.deserialize_and_price(
+                    &arg_buf[..arg_len as usize],
+                    &mut query_arg,
+                )
+            })
+        });
+        result?
     };
 
     if gas_remaining < query_cost {
@@ -194,8 +200,38 @@ pub(crate) fn hq(
     let instance = env.self_instance();
     instance.set_remaining_gas(gas_remaining - query_cost);
 
-    Ok(instance
-        .with_arg_buf_mut(|arg_buf| host_query.execute(&query_arg, arg_buf)))
+    Ok(instance.with_arg_buf_mut(|arg_buf| {
+        maybe_contain_hq_panic(contain_hq_panics, || {
+            host_query.execute(&query_arg, arg_buf)
+        })
+    })?)
+}
+
+fn maybe_contain_hq_panic<R, F>(contain: bool, f: F) -> Result<R, Error>
+where
+    F: FnOnce() -> R,
+{
+    if !contain {
+        return Ok(f());
+    }
+
+    catch_unwind(AssertUnwindSafe(f)).map_err(|payload| {
+        tracing::error!(
+            panic = %hq_panic_message(payload),
+            "host query panicked"
+        );
+        Error::Panic(HOST_QUERY_PANICKED.to_string())
+    })
+}
+
+fn hq_panic_message(payload: Box<dyn Any + Send>) -> String {
+    match payload.downcast::<String>() {
+        Ok(msg) => *msg,
+        Err(payload) => match payload.downcast::<&'static str>() {
+            Ok(msg) => (*msg).to_string(),
+            Err(_) => "host query panicked".to_string(),
+        },
+    }
 }
 
 pub(crate) fn hd(

--- a/piecrust/src/lib.rs
+++ b/piecrust/src/lib.rs
@@ -140,6 +140,6 @@ pub use error::Error;
 pub use piecrust_uplink::*;
 #[cfg(feature = "call-hook")]
 pub use session::CallHook;
-pub use session::{CallReceipt, Session, SessionData};
+pub use session::{CallReceipt, Session, SessionData, SessionDataBuilder};
 pub use store::PageOpening;
 pub use vm::{HostQuery, VM};

--- a/piecrust/src/session.rs
+++ b/piecrust/src/session.rs
@@ -752,6 +752,10 @@ impl Session {
         self.inner().host_queries.get_arc(name)
     }
 
+    pub(crate) fn contain_hq_panics(&self) -> bool {
+        self.inner().data.contain_hq_panics
+    }
+
     pub(crate) fn nth_from_top(&self, n: usize) -> Option<CallTreeElem> {
         self.inner().call_tree.nth_parent(n)
     }
@@ -1076,11 +1080,18 @@ impl CallReceipt<Vec<u8>> {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct SessionData {
     data: BTreeMap<Cow<'static, str>, Vec<u8>>,
     pub base: Option<[u8; 32]>,
     excluded_host_queries: BTreeSet<String>,
+    contain_hq_panics: bool,
+}
+
+impl Default for SessionData {
+    fn default() -> Self {
+        Self::builder().into()
+    }
 }
 
 impl SessionData {
@@ -1089,6 +1100,7 @@ impl SessionData {
             data: BTreeMap::new(),
             base: None,
             excluded_host_queries: BTreeSet::new(),
+            contain_hq_panics: true,
         }
     }
 
@@ -1125,6 +1137,7 @@ pub struct SessionDataBuilder {
     data: BTreeMap<Cow<'static, str>, Vec<u8>>,
     base: Option<[u8; 32]>,
     excluded_host_queries: BTreeSet<String>,
+    contain_hq_panics: bool,
 }
 
 impl SessionDataBuilder {
@@ -1148,11 +1161,22 @@ impl SessionDataBuilder {
         self
     }
 
+    /// Set whether host-query panics are contained at the VM boundary.
+    ///
+    /// Containment is enabled by default. Disabling it lets a panic raised by
+    /// host-query pricing or execution unwind through the VM and abort the
+    /// calling stack.
+    pub fn contain_hq_panics(mut self, contain: bool) -> Self {
+        self.contain_hq_panics = contain;
+        self
+    }
+
     fn build(&self) -> SessionData {
         SessionData {
             data: self.data.clone(),
             base: self.base,
             excluded_host_queries: self.excluded_host_queries.clone(),
+            contain_hq_panics: self.contain_hq_panics,
         }
     }
 }

--- a/piecrust/tests/host.rs
+++ b/piecrust/tests/host.rs
@@ -5,6 +5,7 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use std::any::Any;
+use std::panic::AssertUnwindSafe;
 
 use dusk_plonk::prelude::{
     BlsScalar, Circuit, Compiler, Composer, Constraint, Error as PlonkError,
@@ -12,13 +13,17 @@ use dusk_plonk::prelude::{
 };
 use once_cell::sync::Lazy;
 use piecrust::{
-    ContractData, Error, HostQuery, SessionData, VM, contract_bytecode,
+    ContractData, ContractId, Error, HostQuery, SessionData, VM,
+    contract_bytecode,
 };
+use piecrust_uplink::ContractError;
 use rand::rngs::OsRng;
 use rkyv::Deserialize;
 
 const OWNER: [u8; 32] = [0u8; 32];
 const LIMIT: u64 = 1_000_000;
+const HOST_QUERY_PANICKED: &str = "host query panicked";
+const HOST_CALLER_ID: ContractId = ContractId::from_bytes([1u8; 32]);
 
 fn get_prover_verifier() -> &'static (Prover, Verifier) {
     static PROVER_VERIFIER: Lazy<(Prover, Verifier)> = Lazy::new(|| {
@@ -81,6 +86,38 @@ impl HostQuery for VeryExpensiveQuery {
     }
 }
 
+struct PanicsInPricingQuery;
+
+impl HostQuery for PanicsInPricingQuery {
+    fn deserialize_and_price(
+        &self,
+        _arg_buf: &[u8],
+        _arg: &mut Box<dyn Any>,
+    ) -> u64 {
+        panic!("host query pricing panic")
+    }
+
+    fn execute(&self, _arg: &Box<dyn Any>, _arg_buf: &mut [u8]) -> u32 {
+        unreachable!("pricing panic should prevent execution")
+    }
+}
+
+struct PanicsInExecuteQuery;
+
+impl HostQuery for PanicsInExecuteQuery {
+    fn deserialize_and_price(
+        &self,
+        _arg_buf: &[u8],
+        _arg: &mut Box<dyn Any>,
+    ) -> u64 {
+        0
+    }
+
+    fn execute(&self, _arg: &Box<dyn Any>, _arg_buf: &mut [u8]) -> u32 {
+        panic!("host query execute panic")
+    }
+}
+
 fn new_ephemeral_vm() -> Result<VM, Error> {
     let mut vm = VM::ephemeral()?;
     vm.register_host_query("hash", hash);
@@ -89,17 +126,119 @@ fn new_ephemeral_vm() -> Result<VM, Error> {
     Ok(vm)
 }
 
+fn deploy_host_contract(
+    session: &mut piecrust::Session,
+) -> Result<ContractId, Error> {
+    let (id, _) = session.deploy::<_, (), _>(
+        contract_bytecode!("host"),
+        ContractData::builder().owner(OWNER),
+        LIMIT,
+    )?;
+    Ok(id)
+}
+
+fn deploy_host_contract_with_id(
+    session: &mut piecrust::Session,
+    id: ContractId,
+) -> Result<ContractId, Error> {
+    let (id, _) = session.deploy::<_, (), _>(
+        contract_bytecode!("host"),
+        ContractData::builder().contract_id(id).owner(OWNER),
+        LIMIT,
+    )?;
+    Ok(id)
+}
+
+fn assert_hq_panic(err: Error, expected: &str) {
+    assert!(
+        matches!(err, Error::Panic(ref msg) if msg == expected),
+        "expected Error::Panic({expected:?}), got {err:?}"
+    );
+}
+
+#[test]
+pub fn host_query_pricing_panic_is_contained() -> Result<(), Error> {
+    let mut vm = VM::ephemeral()?;
+    vm.register_host_query("very_expensive", PanicsInPricingQuery);
+    let mut session = vm.session(SessionData::builder())?;
+    let id = deploy_host_contract(&mut session)?;
+
+    let err = session
+        .call::<_, ()>(id, "host_very_expensive", &(), LIMIT)
+        .expect_err("host query pricing panic should be returned as an error");
+
+    assert_hq_panic(err, HOST_QUERY_PANICKED);
+    Ok(())
+}
+
+#[test]
+pub fn host_query_execute_panic_is_contained() -> Result<(), Error> {
+    let mut vm = VM::ephemeral()?;
+    vm.register_host_query("very_expensive", PanicsInExecuteQuery);
+    let mut session = vm.session(SessionData::builder())?;
+    let id = deploy_host_contract(&mut session)?;
+
+    let err = session
+        .call::<_, ()>(id, "host_very_expensive", &(), LIMIT)
+        .expect_err("host query execute panic should be returned as an error");
+
+    assert_hq_panic(err, HOST_QUERY_PANICKED);
+    Ok(())
+}
+
+#[test]
+pub fn nested_host_query_panic_uses_deterministic_message() -> Result<(), Error>
+{
+    let mut vm = VM::ephemeral()?;
+    vm.register_host_query("very_expensive", PanicsInExecuteQuery);
+    let mut session = vm.session(SessionData::builder())?;
+    let host_callee_id = deploy_host_contract(&mut session)?;
+    let host_caller_id =
+        deploy_host_contract_with_id(&mut session, HOST_CALLER_ID)?;
+
+    let receipt = session.call::<_, Result<(), ContractError>>(
+        host_caller_id,
+        "delegate_host_very_expensive",
+        &host_callee_id,
+        LIMIT,
+    )?;
+
+    assert!(
+        matches!(
+            receipt.data,
+            Err(ContractError::Panic(ref msg)) if msg == HOST_QUERY_PANICKED
+        ),
+        "expected deterministic host-query panic, got {:?}",
+        receipt.data
+    );
+
+    Ok(())
+}
+
+#[test]
+pub fn host_query_panic_propagates_when_containment_is_disabled()
+-> Result<(), Error> {
+    let mut vm = VM::ephemeral()?;
+    vm.register_host_query("very_expensive", PanicsInExecuteQuery);
+    let mut session =
+        vm.session(SessionData::builder().contain_hq_panics(false))?;
+    let id = deploy_host_contract(&mut session)?;
+
+    let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        let _ = session.call::<_, ()>(id, "host_very_expensive", &(), LIMIT);
+    }));
+
+    assert!(result.is_err(), "host query panic should propagate");
+    Ok(())
+}
+
 #[test]
 pub fn host_hash() -> Result<(), Error> {
     let vm = new_ephemeral_vm()?;
 
     let mut session = vm.session(SessionData::builder())?;
 
-    let (id, _) = session.deploy::<_, (), _>(
-        contract_bytecode!("host"),
-        ContractData::builder().owner(OWNER),
-        LIMIT,
-    )?;
+    let id = deploy_host_contract(&mut session)?;
 
     let v = vec![0u8, 1, 2];
     let h = session
@@ -117,11 +256,7 @@ pub fn host_very_expensive_oog() -> Result<(), Error> {
 
     let mut session = vm.session(SessionData::builder())?;
 
-    let (id, _) = session.deploy::<_, (), _>(
-        contract_bytecode!("host"),
-        ContractData::builder().owner(OWNER),
-        LIMIT,
-    )?;
+    let id = deploy_host_contract(&mut session)?;
 
     let err = session
         .call::<_, String>(id, "host_very_expensive", &(), LIMIT)
@@ -164,11 +299,7 @@ pub fn host_proof() -> Result<(), Error> {
 
     let mut session = vm.session(SessionData::builder())?;
 
-    let (id, _) = session.deploy::<_, (), _>(
-        contract_bytecode!("host"),
-        ContractData::builder().owner(OWNER),
-        LIMIT,
-    )?;
+    let id = deploy_host_contract(&mut session)?;
 
     // 1. Generate proof and public inputs
     let (prover, _) = get_prover_verifier();


### PR DESCRIPTION
For https://github.com/dusk-network/piecrust-private/issues/31

Catch host-query pricing/execution panics and return contract panic errors.

Adds a session builder flag and regression coverage for contained and propagated behavior.