### PR TITLE
piecrust: update stack benchmark for session API

### DIFF
--- a/piecrust/benches/stack.rs
+++ b/piecrust/benches/stack.rs
@@ -5,51 +5,65 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
-use piecrust::{VM, contract_bytecode};
+use piecrust::{ContractData, SessionData, VM, contract_bytecode};
 
 const SAMPLE_SIZE: usize = 10240;
+const OWNER: [u8; 32] = [0; 32];
+const LIMIT: u64 = 1_000_000;
 
 fn config() -> Criterion {
     Criterion::default().sample_size(SAMPLE_SIZE)
 }
 
 fn push(c: &mut Criterion) {
-    let mut vm = VM::ephemeral().expect("Ephemeral VM should succeed");
+    let vm = VM::ephemeral().expect("Ephemeral VM should succeed");
+    let mut session = vm
+        .session(SessionData::builder())
+        .expect("Session should succeed");
 
-    let id = vm
-        .deploy(contract_bytecode!("stack"))
+    let (id, _) = session
+        .deploy::<_, (), _>(
+            contract_bytecode!("stack"),
+            ContractData::builder().owner(OWNER),
+            LIMIT,
+        )
         .expect("Deployment should succeed");
-
-    let mut session = vm.session();
 
     c.bench_function("push", |b| {
         b.iter(|| {
+            let value = black_box(42);
             session
-                .call::<i32, ()>(id, "push", black_box(42))
+                .call::<_, ()>(id, "push", &value, LIMIT)
                 .expect("Pushing should succeed");
         });
     });
 }
 
 fn pop(c: &mut Criterion) {
-    let mut vm = VM::ephemeral().expect("Ephemeral VM should succeed");
+    let vm = VM::ephemeral().expect("Ephemeral VM should succeed");
+    let mut session = vm
+        .session(SessionData::builder())
+        .expect("Session should succeed");
 
-    let id = vm
-        .deploy(contract_bytecode!("stack"))
+    let (id, _) = session
+        .deploy::<_, (), _>(
+            contract_bytecode!("stack"),
+            ContractData::builder().owner(OWNER),
+            LIMIT,
+        )
         .expect("Deployment should succeed");
 
-    let mut session = vm.session();
-
     for _ in 0..SAMPLE_SIZE {
+        let value = black_box(42);
         session
-            .call(id, "push", black_box(42))
-            .expect("Pushing should succeed")
+            .call::<_, ()>(id, "push", &value, LIMIT)
+            .expect("Pushing should succeed");
     }
 
     c.bench_function("pop", |b| {
         b.iter(|| {
             session
-                .call::<(), Option<i32>>(id, "pop", ())
+                .call::<_, Option<i32>>(id, "pop", &(), LIMIT)
                 .expect("Popping should succeed");
         });
     });


### PR DESCRIPTION
- Stop using old VM-level deploy and call helpers
- Use current SessionData, deploy, and call APIs