### PR TITLE
piecrust: remove once_cell dev dependency

### DIFF
--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Declare minimum supported Rust version of 1.94.
 - Contain host-query panics by default and return them as contract panic errors [#476]
 
+### Removed
+
+- Remove the `once_cell` dev-dependency from tests.
+
 ## [0.32.0] - 2026-06-19
 
 ### Changed

--- a/piecrust/Cargo.toml
+++ b/piecrust/Cargo.toml
@@ -37,7 +37,6 @@ tracing = "0.1.40"
 indexmap = "=2.11" # 2.12 requires rustc edition 2024
 
 [dev-dependencies]
-once_cell = "1.18"
 criterion = "0.4"
 half = "2,<2.5"
 dusk-plonk = { version = "0.22.0-rc.0", features = ["rkyv-impl"] }

--- a/piecrust/tests/host.rs
+++ b/piecrust/tests/host.rs
@@ -6,12 +6,12 @@
 
 use std::any::Any;
 use std::panic::AssertUnwindSafe;
+use std::sync::LazyLock;
 
 use dusk_plonk::prelude::{
     BlsScalar, Circuit, Compiler, Composer, Constraint, Error as PlonkError,
     Proof, Prover, PublicParameters, Verifier,
 };
-use once_cell::sync::Lazy;
 use piecrust::{
     ContractData, ContractId, Error, HostQuery, SessionData, VM,
     contract_bytecode,
@@ -26,18 +26,20 @@ const HOST_QUERY_PANICKED: &str = "host query panicked";
 const HOST_CALLER_ID: ContractId = ContractId::from_bytes([1u8; 32]);
 
 fn get_prover_verifier() -> &'static (Prover, Verifier) {
-    static PROVER_VERIFIER: Lazy<(Prover, Verifier)> = Lazy::new(|| {
-        let mut rng = OsRng;
+    static PROVER_VERIFIER: LazyLock<(Prover, Verifier)> =
+        LazyLock::new(|| {
+            let mut rng = OsRng;
 
-        let pp = PublicParameters::setup(1 << 4, &mut rng)
-            .expect("Generating public parameters should succeed");
-        let label = b"dusk-network";
+            let pp = PublicParameters::setup(1 << 4, &mut rng)
+                .expect("Generating public parameters should succeed");
+            let label = b"dusk-network";
 
-        let (prover, verifier) = Compiler::compile::<TestCircuit>(&pp, label)
-            .expect("Compiling circuit should succeed");
+            let (prover, verifier) =
+                Compiler::compile::<TestCircuit>(&pp, label)
+                    .expect("Compiling circuit should succeed");
 
-        (prover, verifier)
-    });
+            (prover, verifier)
+        });
 
     &PROVER_VERIFIER
 }


### PR DESCRIPTION
Remove the `once_cell` dev-dependency from the test suite and updates the test code to use Rust's standard library equivalent

