### PR TITLE
piecrust: Deduplicate stored contract payloads

### DIFF
--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -16,8 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Declare minimum supported Rust version of 1.94.
 - Contain host-query panics by default and return them as contract panic errors [#476]
 - Move `rand` from runtime dependencies to dev-dependencies.
-- Deduplicate stored contract bytecode and compiled module payloads.
-- Remove unreferenced deduplicated contract payload canonicals.
+- Deduplicate stored contract bytecode and compiled module payloads [#470].
+- Remove unreferenced deduplicated contract payload canonicals [#470].
 
 ### Fixed
 
@@ -586,6 +586,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- ISSUES -->
 [#466]: https://github.com/dusk-network/piecrust/issues/466
+[#470]: https://github.com/dusk-network/piecrust/issues/470
 [#476]: https://github.com/dusk-network/piecrust/issues/476
 
 [#rusk_3341]: https://github.com/dusk-network/rusk/issues/3341

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Declare minimum supported Rust version of 1.94.
 - Contain host-query panics by default and return them as contract panic errors [#476]
 - Move `rand` from runtime dependencies to dev-dependencies.
+- Deduplicate stored contract bytecode and compiled module payloads.
 
 ### Fixed
 

--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Contain host-query panics by default and return them as contract panic errors [#476]
 - Move `rand` from runtime dependencies to dev-dependencies.
 - Deduplicate stored contract bytecode and compiled module payloads.
+- Remove unreferenced deduplicated contract payload canonicals.
 
 ### Fixed
 

--- a/piecrust/src/store.rs
+++ b/piecrust/src/store.rs
@@ -10,6 +10,7 @@ mod baseinfo;
 mod bytecode;
 mod commit;
 mod commit_store;
+mod dedup;
 mod hasher;
 mod index;
 mod memory;

--- a/piecrust/src/store/commit/writer.rs
+++ b/piecrust/src/store/commit/writer.rs
@@ -159,7 +159,7 @@ impl CommitWriter {
                 // we write them to the main location
                 dedup::write(
                     &directories.bytecode_main_dir,
-                    "wasm",
+                    dedup::Kind::Bytecode,
                     bytecode_main_path,
                     contract_data.bytecode.as_ref(),
                 )?;

--- a/piecrust/src/store/commit/writer.rs
+++ b/piecrust/src/store/commit/writer.rs
@@ -20,7 +20,7 @@ use crate::store::hasher::Hash;
 use crate::store::session::ContractDataEntry;
 use crate::store::{
     BASE_FILE, BYTECODE_DIR, Bytecode, ELEMENT_FILE, LEAF_DIR, MAIN_DIR,
-    MEMORY_DIR, METADATA_EXTENSION, Module, OBJECTCODE_EXTENSION,
+    MEMORY_DIR, METADATA_EXTENSION, Module, OBJECTCODE_EXTENSION, dedup,
 };
 
 pub struct CommitWriter;
@@ -157,7 +157,12 @@ impl CommitWriter {
             // metadata files to disk.
             if contract_data.is_new {
                 // we write them to the main location
-                fs::write(bytecode_main_path, &contract_data.bytecode)?;
+                dedup::write(
+                    &directories.bytecode_main_dir,
+                    "wasm",
+                    bytecode_main_path,
+                    contract_data.bytecode.as_ref(),
+                )?;
                 contract_data.module.write_module_data(
                     module_main_path,
                     contract_data.bytecode.as_ref(),

--- a/piecrust/src/store/dedup.rs
+++ b/piecrust/src/store/dedup.rs
@@ -8,6 +8,7 @@ use std::fs::{self, OpenOptions};
 use std::io::{self, Write};
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
+use std::process;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -58,7 +59,7 @@ where
     replace_with_hard_link_or_copy(&canonical, target)?;
 
     if let Some(old_hash) = old_hash.filter(|old_hash| old_hash != &hash) {
-        remove_unreferenced_hash(store_root, kind, &old_hash)?;
+        remove_unreferenced_hash_best_effort(store_root, kind, &old_hash);
     }
 
     Ok(())
@@ -81,12 +82,26 @@ where
     match fs::remove_file(target) {
         Ok(()) => {
             if let Some(hash) = hash {
-                remove_unreferenced_hash(store_root, kind, &hash)?;
+                remove_unreferenced_hash_best_effort(store_root, kind, &hash);
             }
             Ok(())
         }
         Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
         Err(err) => Err(err),
+    }
+}
+
+fn remove_unreferenced_hash_best_effort(
+    store_root: &Path,
+    kind: Kind,
+    hash: &str,
+) {
+    if let Err(err) = remove_unreferenced_hash(store_root, kind, hash) {
+        tracing::warn!(
+            kind = kind.directory(),
+            hash,
+            "failed to remove unreferenced dedup canonical: {err}"
+        );
     }
 }
 
@@ -181,14 +196,21 @@ fn replace_with_hard_link_or_copy(
         }
         Err(_) => {
             let _ = fs::remove_file(&tmp);
-            let result = fs::copy(canonical, &tmp)
-                .and_then(|_| fs::rename(&tmp, target));
-            if result.is_err() {
-                let _ = fs::remove_file(&tmp);
-            }
-            result
+            replace_with_copy(canonical, target, &tmp)
         }
     }
+}
+
+fn replace_with_copy(
+    canonical: &Path,
+    target: &Path,
+    tmp: &Path,
+) -> io::Result<()> {
+    let result = fs::copy(canonical, tmp).and_then(|_| fs::rename(tmp, target));
+    if result.is_err() {
+        let _ = fs::remove_file(tmp);
+    }
+    result
 }
 
 fn tmp_path(path: &Path) -> PathBuf {
@@ -200,13 +222,29 @@ fn tmp_path(path: &Path) -> PathBuf {
 
     path.with_file_name(format!(
         ".{file_name}.dedup-tmp-{}-{counter}",
-        std::process::id()
+        process::id()
     ))
 }
 
 #[cfg(test)]
 mod tests {
+    use std::os::unix::fs::PermissionsExt;
+
     use super::*;
+
+    fn canonical_path(store_root: &Path, kind: Kind, bytes: &[u8]) -> PathBuf {
+        store_root
+            .join(DEDUP_DIR)
+            .join(kind.directory())
+            .join(hash_bytes(bytes))
+    }
+
+    fn set_mode(path: &Path, mode: u32) {
+        let mut permissions =
+            fs::metadata(path).expect("metadata").permissions();
+        permissions.set_mode(mode);
+        fs::set_permissions(path, permissions).expect("set permissions");
+    }
 
     #[test]
     fn hard_link_rename_failure_removes_tmp_link() {
@@ -226,5 +264,82 @@ mod tests {
             .any(|name| name.to_string_lossy().contains("dedup-tmp"));
         assert!(!leaked_tmp);
         assert_eq!(fs::metadata(&canonical).expect("metadata").nlink(), 1);
+    }
+
+    #[test]
+    fn copy_fallback_creates_independent_target() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store_root = dir.path();
+        let kind = Kind::Bytecode;
+        let bytes = b"canonical bytecode";
+        let canonical = canonical_path(store_root, kind, bytes);
+        let target = store_root.join("target");
+        let tmp = tmp_path(&target);
+
+        fs::create_dir_all(canonical.parent().expect("canonical dir"))
+            .expect("canonical dir");
+        fs::write(&canonical, bytes).expect("canonical");
+
+        replace_with_copy(&canonical, &target, &tmp)
+            .expect("copy fallback should write target");
+
+        assert_eq!(fs::read(&target).expect("read target"), bytes);
+        assert_ne!(
+            fs::metadata(&canonical).expect("canonical metadata").ino(),
+            fs::metadata(&target).expect("target metadata").ino()
+        );
+
+        remove_unreferenced_hash(store_root, kind, &hash_bytes(bytes))
+            .expect("evict unreferenced canonical");
+
+        assert!(!canonical.exists());
+        assert_eq!(fs::read(&target).expect("read copied target"), bytes);
+    }
+
+    #[test]
+    fn write_ignores_old_canonical_eviction_failure() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store_root = dir.path();
+        let target = store_root.join("target");
+        let kind = Kind::Bytecode;
+        let old_bytes = b"old bytecode";
+        let new_bytes = b"new bytecode";
+
+        write(store_root, kind, &target, old_bytes).expect("write old bytes");
+
+        let canonical_dir = store_root.join(DEDUP_DIR).join(kind.directory());
+        let old_canonical = canonical_path(store_root, kind, old_bytes);
+        let new_canonical = canonical_path(store_root, kind, new_bytes);
+        fs::write(&new_canonical, new_bytes).expect("write new canonical");
+        set_mode(&canonical_dir, 0o500);
+
+        write(store_root, kind, &target, new_bytes)
+            .expect("write should ignore old canonical cleanup failure");
+
+        set_mode(&canonical_dir, 0o700);
+        assert_eq!(fs::read(&target).expect("read target"), new_bytes);
+        assert!(old_canonical.exists());
+    }
+
+    #[test]
+    fn remove_file_ignores_canonical_eviction_failure() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store_root = dir.path();
+        let target = store_root.join("target");
+        let kind = Kind::Bytecode;
+        let bytes = b"bytecode";
+
+        write(store_root, kind, &target, bytes).expect("write bytes");
+
+        let canonical_dir = store_root.join(DEDUP_DIR).join(kind.directory());
+        let canonical = canonical_path(store_root, kind, bytes);
+        set_mode(&canonical_dir, 0o500);
+
+        remove_file(store_root, kind, &target)
+            .expect("remove should ignore canonical cleanup failure");
+
+        set_mode(&canonical_dir, 0o700);
+        assert!(!target.exists());
+        assert!(canonical.exists());
     }
 }

--- a/piecrust/src/store/dedup.rs
+++ b/piecrust/src/store/dedup.rs
@@ -6,15 +6,36 @@
 
 use std::fs::{self, OpenOptions};
 use std::io::{self, Write};
+use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 const DEDUP_DIR: &str = ".dedup";
+const HASH_HEX_LEN: usize = blake3::OUT_LEN * 2;
 static TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+static DEDUP_LOCK: Mutex<()> = Mutex::new(());
+
+#[derive(Clone, Copy)]
+pub(crate) enum Kind {
+    Bytecode,
+    Objectcode,
+    ObjectcodeMeta,
+}
+
+impl Kind {
+    fn directory(self) -> &'static str {
+        match self {
+            Self::Bytecode => "bytecode",
+            Self::Objectcode => "objectcode",
+            Self::ObjectcodeMeta => "objectcode-meta",
+        }
+    }
+}
 
 pub(crate) fn write<P, T, B>(
     store_root: P,
-    kind: &str,
+    kind: Kind,
     target: T,
     bytes: B,
 ) -> io::Result<()>
@@ -23,16 +44,93 @@ where
     T: AsRef<Path>,
     B: AsRef<[u8]>,
 {
+    let _guard = DEDUP_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let store_root = store_root.as_ref();
     let target = target.as_ref();
     let bytes = bytes.as_ref();
-    let hash = blake3::hash(bytes).to_hex().to_string();
-    let canonical_dir = store_root.join(DEDUP_DIR).join(kind);
-    let canonical = canonical_dir.join(hash);
+    let hash = hash_bytes(bytes);
+    let old_hash = file_hash(target)?;
+    let canonical_dir = store_root.join(DEDUP_DIR).join(kind.directory());
+    let canonical = canonical_dir.join(&hash);
 
     fs::create_dir_all(&canonical_dir)?;
     write_canonical_if_missing(&canonical, bytes)?;
-    replace_with_hard_link_or_copy(&canonical, target)
+    replace_with_hard_link_or_copy(&canonical, target)?;
+
+    if let Some(old_hash) = old_hash.filter(|old_hash| old_hash != &hash) {
+        remove_unreferenced_hash(store_root, kind, &old_hash)?;
+    }
+
+    Ok(())
+}
+
+pub(crate) fn remove_file<P, T>(
+    store_root: P,
+    kind: Kind,
+    target: T,
+) -> io::Result<()>
+where
+    P: AsRef<Path>,
+    T: AsRef<Path>,
+{
+    let _guard = DEDUP_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let store_root = store_root.as_ref();
+    let target = target.as_ref();
+    let hash = file_hash(target)?;
+
+    match fs::remove_file(target) {
+        Ok(()) => {
+            if let Some(hash) = hash {
+                remove_unreferenced_hash(store_root, kind, &hash)?;
+            }
+            Ok(())
+        }
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err),
+    }
+}
+
+fn remove_unreferenced_hash(
+    store_root: &Path,
+    kind: Kind,
+    hash: &str,
+) -> io::Result<()> {
+    if !is_hash(hash) {
+        return Ok(());
+    }
+
+    let canonical =
+        store_root.join(DEDUP_DIR).join(kind.directory()).join(hash);
+
+    if !canonical.is_file() {
+        return Ok(());
+    }
+
+    if has_live_hard_link(&canonical)? {
+        return Ok(());
+    }
+
+    fs::remove_file(canonical)
+}
+
+fn has_live_hard_link(path: &Path) -> io::Result<bool> {
+    Ok(fs::metadata(path)?.nlink() > 1)
+}
+
+fn file_hash(path: &Path) -> io::Result<Option<String>> {
+    match fs::read(path) {
+        Ok(bytes) => Ok(Some(hash_bytes(&bytes))),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(err),
+    }
+}
+
+fn hash_bytes(bytes: &[u8]) -> String {
+    blake3::hash(bytes).to_hex().to_string()
+}
+
+fn is_hash(hash: &str) -> bool {
+    hash.len() == HASH_HEX_LEN && hash.bytes().all(|b| b.is_ascii_hexdigit())
 }
 
 fn write_canonical_if_missing(path: &Path, bytes: &[u8]) -> io::Result<()> {
@@ -74,7 +172,13 @@ fn replace_with_hard_link_or_copy(
     let _ = fs::remove_file(&tmp);
 
     match fs::hard_link(canonical, &tmp) {
-        Ok(()) => fs::rename(&tmp, target),
+        Ok(()) => {
+            let result = fs::rename(&tmp, target);
+            if result.is_err() {
+                let _ = fs::remove_file(&tmp);
+            }
+            result
+        }
         Err(_) => {
             let _ = fs::remove_file(&tmp);
             let result = fs::copy(canonical, &tmp)
@@ -98,4 +202,29 @@ fn tmp_path(path: &Path) -> PathBuf {
         ".{file_name}.dedup-tmp-{}-{counter}",
         std::process::id()
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hard_link_rename_failure_removes_tmp_link() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let canonical = dir.path().join("canonical");
+        let target = dir.path().join("target");
+
+        fs::write(&canonical, b"canonical").expect("canonical");
+        fs::create_dir(&target).expect("target dir");
+
+        replace_with_hard_link_or_copy(&canonical, &target)
+            .expect_err("rename over directory should fail");
+
+        let leaked_tmp = fs::read_dir(dir.path())
+            .expect("read tempdir")
+            .map(|entry| entry.expect("dir entry").file_name())
+            .any(|name| name.to_string_lossy().contains("dedup-tmp"));
+        assert!(!leaked_tmp);
+        assert_eq!(fs::metadata(&canonical).expect("metadata").nlink(), 1);
+    }
 }

--- a/piecrust/src/store/dedup.rs
+++ b/piecrust/src/store/dedup.rs
@@ -1,0 +1,101 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+const DEDUP_DIR: &str = ".dedup";
+static TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+pub(crate) fn write<P, T, B>(
+    store_root: P,
+    kind: &str,
+    target: T,
+    bytes: B,
+) -> io::Result<()>
+where
+    P: AsRef<Path>,
+    T: AsRef<Path>,
+    B: AsRef<[u8]>,
+{
+    let store_root = store_root.as_ref();
+    let target = target.as_ref();
+    let bytes = bytes.as_ref();
+    let hash = blake3::hash(bytes).to_hex().to_string();
+    let canonical_dir = store_root.join(DEDUP_DIR).join(kind);
+    let canonical = canonical_dir.join(hash);
+
+    fs::create_dir_all(&canonical_dir)?;
+    write_canonical_if_missing(&canonical, bytes)?;
+    replace_with_hard_link_or_copy(&canonical, target)
+}
+
+fn write_canonical_if_missing(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    match fs::read(path) {
+        Ok(existing) if existing == bytes => Ok(()),
+        Ok(_) => replace_file(path, bytes),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => {
+            replace_file(path, bytes)
+        }
+        Err(err) => Err(err),
+    }
+}
+
+fn replace_file(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    let tmp = tmp_path(path);
+    let result = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&tmp)
+        .and_then(|mut file| file.write_all(bytes))
+        .and_then(|_| fs::rename(&tmp, path));
+
+    if result.is_err() {
+        let _ = fs::remove_file(&tmp);
+    }
+
+    result
+}
+
+fn replace_with_hard_link_or_copy(
+    canonical: &Path,
+    target: &Path,
+) -> io::Result<()> {
+    if let Some(parent) = target.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let tmp = tmp_path(target);
+    let _ = fs::remove_file(&tmp);
+
+    match fs::hard_link(canonical, &tmp) {
+        Ok(()) => fs::rename(&tmp, target),
+        Err(_) => {
+            let _ = fs::remove_file(&tmp);
+            let result = fs::copy(canonical, &tmp)
+                .and_then(|_| fs::rename(&tmp, target));
+            if result.is_err() {
+                let _ = fs::remove_file(&tmp);
+            }
+            result
+        }
+    }
+}
+
+fn tmp_path(path: &Path) -> PathBuf {
+    let counter = TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let file_name = path
+        .file_name()
+        .map(|name| name.to_string_lossy())
+        .unwrap_or_else(|| "dedup".into());
+
+    path.with_file_name(format!(
+        ".{file_name}.dedup-tmp-{}-{counter}",
+        std::process::id()
+    ))
+}

--- a/piecrust/src/store/module.rs
+++ b/piecrust/src/store/module.rs
@@ -12,6 +12,8 @@ use std::{env, fs, io, mem};
 
 use dusk_wasmtime::Engine;
 
+use super::dedup;
+
 /// WASM object code belonging to a given contract.
 #[derive(Debug, Clone)]
 pub struct Module {
@@ -93,17 +95,13 @@ fn invalidate_cached_modules(module_path: &Path) {
         .retain(|key, _| key.path != module_path);
 }
 
-fn write_cache_meta(
-    module_path: &Path,
-    module_bytes: &[u8],
-    bytecode: &[u8],
-) -> io::Result<()> {
+fn cache_meta_bytes(module_bytes: &[u8], bytecode: &[u8]) -> Vec<u8> {
     let mut meta = Vec::with_capacity(MODULE_CACHE_META_LEN);
     meta.extend_from_slice(&MODULE_CACHE_META_VERSION.to_le_bytes());
     meta.extend_from_slice(blake3::hash(bytecode).as_bytes());
     meta.extend_from_slice(blake3::hash(module_bytes).as_bytes());
     meta.extend_from_slice(cache_runtime_fingerprint().as_bytes());
-    fs::write(cache_meta_path(module_path), meta)
+    meta
 }
 
 fn validate_cache_meta(
@@ -248,9 +246,19 @@ impl Module {
         bytecode: &[u8],
     ) -> io::Result<()> {
         let module_path = module_path.as_ref();
+        let store_root = module_path.parent().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("module path has no parent: {module_path:?}"),
+            )
+        })?;
         let module_bytes = self.serialize();
-        fs::write(module_path, &module_bytes)?;
-        write_cache_meta(module_path, &module_bytes, bytecode)?;
+        dedup::write(store_root, "objectcode", module_path, &module_bytes)?;
+
+        let meta_path = cache_meta_path(module_path);
+        let meta = cache_meta_bytes(&module_bytes, bytecode);
+        dedup::write(store_root, "objectcode-meta", meta_path, meta)?;
+
         insert_cached_module(module_path, bytecode, self);
         Ok(())
     }

--- a/piecrust/src/store/module.rs
+++ b/piecrust/src/store/module.rs
@@ -253,11 +253,16 @@ impl Module {
             )
         })?;
         let module_bytes = self.serialize();
-        dedup::write(store_root, "objectcode", module_path, &module_bytes)?;
+        dedup::write(
+            store_root,
+            dedup::Kind::Objectcode,
+            module_path,
+            &module_bytes,
+        )?;
 
         let meta_path = cache_meta_path(module_path);
         let meta = cache_meta_bytes(&module_bytes, bytecode);
-        dedup::write(store_root, "objectcode-meta", meta_path, meta)?;
+        dedup::write(store_root, dedup::Kind::ObjectcodeMeta, meta_path, meta)?;
 
         insert_cached_module(module_path, bytecode, self);
         Ok(())
@@ -345,13 +350,14 @@ impl Module {
 
         invalidate_cached_modules(module_path);
 
-        if module_path.exists() {
-            fs::remove_file(module_path)?;
-        }
-
-        if meta_path.exists() {
-            fs::remove_file(meta_path)?;
-        }
+        let store_root = module_path.parent().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("module path has no parent: {module_path:?}"),
+            )
+        })?;
+        dedup::remove_file(store_root, dedup::Kind::Objectcode, module_path)?;
+        dedup::remove_file(store_root, dedup::Kind::ObjectcodeMeta, meta_path)?;
 
         Ok(())
     }

--- a/piecrust/tests/module.rs
+++ b/piecrust/tests/module.rs
@@ -304,6 +304,85 @@ fn migration_removes_replaced_bytecode_canonical() -> Result<(), Error> {
 }
 
 #[test]
+fn migration_of_duplicate_bytecode_keeps_shared_canonical() -> Result<(), Error>
+{
+    let vm = VM::ephemeral()?;
+    let counter_a = ContractId::from_bytes([7; 32]);
+    let counter_b = ContractId::from_bytes([8; 32]);
+    let mut session = vm.session(SessionData::builder())?;
+
+    session.deploy::<_, (), _>(
+        contract_bytecode!("counter"),
+        ContractData::builder().owner(OWNER).contract_id(counter_a),
+        LIMIT,
+    )?;
+    session.deploy::<_, (), _>(
+        contract_bytecode!("counter"),
+        ContractData::builder().owner(OWNER).contract_id(counter_b),
+        LIMIT,
+    )?;
+    let root = session.commit()?;
+
+    let old_canonical =
+        dedup_canonical_path(&vm, "bytecode", contract_bytecode!("counter"));
+    assert!(old_canonical.exists());
+
+    let mut session = vm.session(SessionData::builder().base(root))?;
+    session = session.migrate(
+        counter_a,
+        contract_bytecode!("double_counter"),
+        ContractData::builder(),
+        LIMIT,
+        |new_contract, session| {
+            let old_counter_value = session
+                .call::<_, i64>(counter_a, "read_value", &(), LIMIT)?
+                .data;
+            let (left_counter_value, _) = session
+                .call::<_, (i64, i64)>(new_contract, "read_values", &(), LIMIT)?
+                .data;
+            let diff = old_counter_value - left_counter_value;
+
+            for _ in 0..diff {
+                session.call::<_, ()>(
+                    new_contract,
+                    "increment_left",
+                    &(),
+                    LIMIT,
+                )?;
+            }
+
+            Ok(())
+        },
+    )?;
+    let root = session.commit()?;
+
+    let new_canonical = dedup_canonical_path(
+        &vm,
+        "bytecode",
+        contract_bytecode!("double_counter"),
+    );
+    assert!(old_canonical.exists());
+    assert!(new_canonical.exists());
+    assert!(bytecode_path(&vm, counter_b).exists());
+
+    let mut session = vm.session(SessionData::builder().base(root))?;
+    assert_eq!(
+        session
+            .call::<_, (i64, i64)>(counter_a, "read_values", &(), LIMIT)?
+            .data,
+        (0xfc, 0xcf)
+    );
+    assert_eq!(
+        session
+            .call::<_, i64>(counter_b, "read_value", &(), LIMIT)?
+            .data,
+        0xfc
+    );
+
+    Ok(())
+}
+
+#[test]
 fn recompile_module() -> Result<(), Error> {
     let vm = VM::ephemeral()?;
     let (counter_id, commit_id) = deploy_counter(&vm)?;

--- a/piecrust/tests/module.rs
+++ b/piecrust/tests/module.rs
@@ -4,6 +4,8 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -27,6 +29,14 @@ fn module_meta_path(vm: &VM, contract_id: ContractId) -> PathBuf {
     module.with_extension("a.meta")
 }
 
+fn bytecode_path(vm: &VM, contract_id: ContractId) -> PathBuf {
+    let contract_hex = hex::encode(contract_id);
+    vm.root_dir()
+        .join("main")
+        .join("bytecode")
+        .join(&contract_hex)
+}
+
 fn deploy_counter(vm: &VM) -> Result<(ContractId, [u8; 32]), Error> {
     let mut session = vm.session(SessionData::builder())?;
     let (counter_id, _) = session.deploy::<_, (), _>(
@@ -41,6 +51,62 @@ fn deploy_counter(vm: &VM) -> Result<(ContractId, [u8; 32]), Error> {
 
 fn io_to_error(err: std::io::Error) -> Error {
     Error::PersistenceError(Arc::new(err))
+}
+
+#[cfg(unix)]
+fn inode(path: &PathBuf) -> Result<u64, Error> {
+    Ok(std::fs::metadata(path).map_err(io_to_error)?.ino())
+}
+
+#[cfg(unix)]
+#[test]
+fn duplicate_bytecode_and_modules_share_storage() -> Result<(), Error> {
+    let vm = VM::ephemeral()?;
+    let counter_a = ContractId::from_bytes([3; 32]);
+    let counter_b = ContractId::from_bytes([4; 32]);
+    let mut session = vm.session(SessionData::builder())?;
+
+    session.deploy::<_, (), _>(
+        contract_bytecode!("counter"),
+        ContractData::builder().owner(OWNER).contract_id(counter_a),
+        LIMIT,
+    )?;
+    session.deploy::<_, (), _>(
+        contract_bytecode!("counter"),
+        ContractData::builder().owner(OWNER).contract_id(counter_b),
+        LIMIT,
+    )?;
+    let commit_id = session.commit()?;
+
+    assert_eq!(
+        inode(&bytecode_path(&vm, counter_a))?,
+        inode(&bytecode_path(&vm, counter_b))?
+    );
+    assert_eq!(
+        inode(&module_path(&vm, counter_a))?,
+        inode(&module_path(&vm, counter_b))?
+    );
+    assert_eq!(
+        inode(&module_meta_path(&vm, counter_a))?,
+        inode(&module_meta_path(&vm, counter_b))?
+    );
+
+    let vm = VM::new(vm.root_dir())?;
+    let mut session = vm.session(SessionData::builder().base(commit_id))?;
+    assert_eq!(
+        session
+            .call::<_, i64>(counter_a, "read_value", &(), LIMIT)?
+            .data,
+        0xfc
+    );
+    assert_eq!(
+        session
+            .call::<_, i64>(counter_b, "read_value", &(), LIMIT)?
+            .data,
+        0xfc
+    );
+
+    Ok(())
 }
 
 #[test]

--- a/piecrust/tests/module.rs
+++ b/piecrust/tests/module.rs
@@ -6,7 +6,7 @@
 
 #[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use piecrust::{ContractData, Error, SessionData, VM, contract_bytecode};
@@ -15,13 +15,13 @@ use piecrust_uplink::ContractId;
 const OWNER: [u8; 32] = [0u8; 32];
 const LIMIT: u64 = 1_000_000;
 
+fn bytecode_dir(vm: &VM) -> PathBuf {
+    vm.root_dir().join("main").join("bytecode")
+}
+
 fn module_path(vm: &VM, contract_id: ContractId) -> PathBuf {
     let contract_hex = hex::encode(contract_id);
-    vm.root_dir()
-        .join("main") // MAIN_DIR
-        .join("bytecode") // BYTECODE_DIR
-        .join(&contract_hex)
-        .with_extension("a") // OBJECTCODE_EXTENSION
+    bytecode_dir(vm).join(&contract_hex).with_extension("a") // OBJECTCODE_EXTENSION
 }
 
 fn module_meta_path(vm: &VM, contract_id: ContractId) -> PathBuf {
@@ -31,10 +31,23 @@ fn module_meta_path(vm: &VM, contract_id: ContractId) -> PathBuf {
 
 fn bytecode_path(vm: &VM, contract_id: ContractId) -> PathBuf {
     let contract_hex = hex::encode(contract_id);
-    vm.root_dir()
-        .join("main")
-        .join("bytecode")
-        .join(&contract_hex)
+    bytecode_dir(vm).join(&contract_hex)
+}
+
+fn dedup_canonical_path(vm: &VM, kind: &str, bytes: &[u8]) -> PathBuf {
+    bytecode_dir(vm)
+        .join(".dedup")
+        .join(kind)
+        .join(blake3::hash(bytes).to_hex().to_string())
+}
+
+fn dedup_canonical_path_for_file(
+    vm: &VM,
+    kind: &str,
+    path: &Path,
+) -> Result<PathBuf, Error> {
+    let bytes = std::fs::read(path).map_err(io_to_error)?;
+    Ok(dedup_canonical_path(vm, kind, &bytes))
 }
 
 fn deploy_counter(vm: &VM) -> Result<(ContractId, [u8; 32]), Error> {
@@ -116,16 +129,39 @@ fn remove_module() -> Result<(), Error> {
 
     let module_file = module_path(&vm, counter_id);
     let module_meta_file = module_meta_path(&vm, counter_id);
+    let module_canonical =
+        dedup_canonical_path_for_file(&vm, "objectcode", &module_file)?;
+    let module_meta_canonical = dedup_canonical_path_for_file(
+        &vm,
+        "objectcode-meta",
+        &module_meta_file,
+    )?;
     assert!(module_file.exists());
     assert!(module_meta_file.exists());
+    assert!(module_canonical.exists());
+    assert!(module_meta_canonical.exists());
 
     vm.remove_module(counter_id)?;
     assert!(!module_file.exists());
     assert!(!module_meta_file.exists());
+    assert!(!module_canonical.exists());
+    assert!(!module_meta_canonical.exists());
 
     vm.recompile_module(counter_id)?;
     assert!(module_file.exists());
     assert!(module_meta_file.exists());
+    assert!(
+        dedup_canonical_path_for_file(&vm, "objectcode", &module_file)?
+            .exists()
+    );
+    assert!(
+        dedup_canonical_path_for_file(
+            &vm,
+            "objectcode-meta",
+            &module_meta_file
+        )?
+        .exists()
+    );
 
     let mut session = vm.session(SessionData::builder().base(commit_id))?;
     assert_eq!(
@@ -140,6 +176,128 @@ fn remove_module() -> Result<(), Error> {
             .call::<_, i64>(counter_id, "read_value", &(), LIMIT)?
             .data,
         0xfe
+    );
+
+    Ok(())
+}
+
+#[test]
+fn removing_duplicate_module_keeps_shared_canonical() -> Result<(), Error> {
+    let vm = VM::ephemeral()?;
+    let counter_a = ContractId::from_bytes([5; 32]);
+    let counter_b = ContractId::from_bytes([6; 32]);
+    let mut session = vm.session(SessionData::builder())?;
+
+    session.deploy::<_, (), _>(
+        contract_bytecode!("counter"),
+        ContractData::builder().owner(OWNER).contract_id(counter_a),
+        LIMIT,
+    )?;
+    session.deploy::<_, (), _>(
+        contract_bytecode!("counter"),
+        ContractData::builder().owner(OWNER).contract_id(counter_b),
+        LIMIT,
+    )?;
+    let commit_id = session.commit()?;
+
+    let module_a = module_path(&vm, counter_a);
+    let module_b = module_path(&vm, counter_b);
+    let meta_a = module_meta_path(&vm, counter_a);
+    let meta_b = module_meta_path(&vm, counter_b);
+    let module_canonical =
+        dedup_canonical_path_for_file(&vm, "objectcode", &module_a)?;
+    let meta_canonical =
+        dedup_canonical_path_for_file(&vm, "objectcode-meta", &meta_a)?;
+
+    vm.remove_module(counter_a)?;
+
+    assert!(!module_a.exists());
+    assert!(!meta_a.exists());
+    assert!(module_b.exists());
+    assert!(meta_b.exists());
+    assert!(module_canonical.exists());
+    assert!(meta_canonical.exists());
+
+    vm.recompile_module(counter_a)?;
+
+    let mut session = vm.session(SessionData::builder().base(commit_id))?;
+    assert_eq!(
+        session
+            .call::<_, i64>(counter_a, "read_value", &(), LIMIT)?
+            .data,
+        0xfc
+    );
+    assert_eq!(
+        session
+            .call::<_, i64>(counter_b, "read_value", &(), LIMIT)?
+            .data,
+        0xfc
+    );
+
+    Ok(())
+}
+
+#[test]
+fn migration_removes_replaced_bytecode_canonical() -> Result<(), Error> {
+    let vm = VM::ephemeral()?;
+    let mut session = vm.session(SessionData::builder())?;
+
+    let (contract, _) = session.deploy::<_, (), _>(
+        contract_bytecode!("counter"),
+        ContractData::builder().owner(OWNER),
+        LIMIT,
+    )?;
+    session.call::<_, ()>(contract, "increment", &(), LIMIT)?;
+    session.call::<_, ()>(contract, "increment", &(), LIMIT)?;
+    let root = session.commit()?;
+
+    let old_canonical =
+        dedup_canonical_path(&vm, "bytecode", contract_bytecode!("counter"));
+    assert!(old_canonical.exists());
+
+    let mut session = vm.session(SessionData::builder().base(root))?;
+    session = session.migrate(
+        contract,
+        contract_bytecode!("double_counter"),
+        ContractData::builder(),
+        LIMIT,
+        |new_contract, session| {
+            let old_counter_value = session
+                .call::<_, i64>(contract, "read_value", &(), LIMIT)?
+                .data;
+            let (left_counter_value, _) = session
+                .call::<_, (i64, i64)>(new_contract, "read_values", &(), LIMIT)?
+                .data;
+            let diff = old_counter_value - left_counter_value;
+
+            for _ in 0..diff {
+                session.call::<_, ()>(
+                    new_contract,
+                    "increment_left",
+                    &(),
+                    LIMIT,
+                )?;
+            }
+
+            Ok(())
+        },
+    )?;
+    let root = session.commit()?;
+
+    let new_canonical = dedup_canonical_path(
+        &vm,
+        "bytecode",
+        contract_bytecode!("double_counter"),
+    );
+    assert!(!old_canonical.exists());
+    assert!(new_canonical.exists());
+
+    let mut session = vm.session(SessionData::builder().base(root))?;
+    assert_eq!(
+        session
+            .call::<_, (i64, i64)>(contract, "read_values", &(), LIMIT)?
+            .data,
+        (0xfe, 0xcf)
     );
 
     Ok(())


### PR DESCRIPTION
Resolves dusk-network/piecrust#470.

Moved from dusk-network/piecrust-private#24.

## Rationale

Repeated deployments of the same contract currently duplicate the raw WASM and compiled module artifacts on disk. This is wasteful for token factories, collections, or any workflow where many contracts share identical bytecode but have different deployment IDs or initial state.

This change stores contract payloads by content hash and links deployment-specific files to the canonical payload. Existing states remain readable because the layout only affects newly written payloads; old files are left where they are. If hard links are not available, the implementation falls back to copying so the storage path remains portable.

The change was validated with regression coverage for duplicate deployments, VM reopen behavior, and local persisted-state testing with historic deployments followed by new duplicate deployments.

## Validation

- `make fmt CHECK=1`
- `cargo check -p piecrust --lib --all-features`
- `git diff --check origin/main..HEAD`
- `make test`
- `make cq`
- `make no-std`