### PR TITLE
Declare Unix target support

### DIFF
--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `SessionDataBuilder::contain_hq_panics` opt-out for callers that need host-query panics to propagate [#476]
+- Declare unsupported non-Unix targets at compile time.
 
 ### Changed
 

--- a/piecrust/src/lib.rs
+++ b/piecrust/src/lib.rs
@@ -119,6 +119,9 @@
 //! [runtime docs]: dusk_wasmtime::Config::consume_fuel
 //! [`deletions`]: VM::delete_commit
 
+#[cfg(not(unix))]
+compile_error!("Piecrust only supports Unix targets.");
+
 #[macro_use]
 mod bytecode_macro;
 mod call_tree;


### PR DESCRIPTION
Add an explicit compile-time error for non-Unix Piecrust targets
