### PR TITLE
piecrust: reject contract merkle position collisions

### DIFF
--- a/piecrust/CHANGELOG.md
+++ b/piecrust/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Reject distinct explicit `ContractId`s that map to an occupied contract Merkle position.
 - Preserve queued `finalize_commit` operations when a commit is held by a live session.
 
 ### Removed

--- a/piecrust/src/error.rs
+++ b/piecrust/src/error.rs
@@ -32,6 +32,8 @@ pub enum Error {
     ContractCacheError(Arc<std::io::Error>),
     #[error("Contract does not exist: {0}")]
     ContractDoesNotExist(ContractId),
+    #[error("Contract '{contract_id}' collides at Merkle position {pos}")]
+    ContractPositionCollision { contract_id: ContractId, pos: u64 },
     #[error(transparent)]
     FeedPulled(mpsc::SendError<Vec<u8>>),
     #[error(transparent)]

--- a/piecrust/src/session.rs
+++ b/piecrust/src/session.rs
@@ -267,11 +267,12 @@ impl Session {
     /// to fit into a sparse merkle tree with `2^32` positions, and as such
     /// a 256-bit number has to be mapped into a 32-bit number.
     ///
-    /// If such a collision occurs, [`PersistenceError`] will be returned.
+    /// If such a collision occurs, [`ContractPositionCollision`] will be
+    /// returned.
     ///
     /// [`ContractId`]: ContractId
     /// [`CallReceipt`]: CallReceipt
-    /// [`PersistenceError`]: PersistenceError
+    /// [`ContractPositionCollision`]: Error::ContractPositionCollision
     ///
     /// # Panics
     /// If `deploy_data` does not specify an owner, this will panic.
@@ -334,11 +335,12 @@ impl Session {
     /// to fit into a sparse merkle tree with `2^32` positions, and as such
     /// a 256-bit number has to be mapped into a 32-bit number.
     ///
-    /// If such a collision occurs, [`PersistenceError`] will be returned.
+    /// If such a collision occurs, [`ContractPositionCollision`] will be
+    /// returned.
     ///
     /// [`ContractId`]: ContractId
     /// [`CallReceipt`]: CallReceipt
-    /// [`PersistenceError`]: PersistenceError
+    /// [`ContractPositionCollision`]: Error::ContractPositionCollision
     #[allow(clippy::type_complexity)]
     pub fn deploy_raw(
         &mut self,
@@ -382,16 +384,13 @@ impl Session {
         let contract_metadata = ContractMetadata { contract_id, owner };
         let metadata_bytes = Self::serialize_data(&contract_metadata)?;
 
-        self.inner_mut()
-            .contract_session
-            .deploy(
-                contract_id,
-                bytecode,
-                wrapped_contract.as_bytes(),
-                contract_metadata,
-                metadata_bytes.as_slice(),
-            )
-            .map_err(|err| PersistenceError(Arc::new(err)))?;
+        self.inner_mut().contract_session.deploy(
+            contract_id,
+            bytecode,
+            wrapped_contract.as_bytes(),
+            contract_metadata,
+            metadata_bytes.as_slice(),
+        )?;
         self.inner_mut().compiled_modules.remove(&contract_id);
 
         let instantiate = || {
@@ -457,7 +456,9 @@ impl Session {
             + for<'b> CheckBytes<DefaultValidator<'b>>,
     {
         if fn_name == INIT_METHOD {
-            return Err(InitalizationError("init call not allowed".into()));
+            return Err(Error::InitalizationError(
+                "init call not allowed".into(),
+            ));
         }
 
         let mut sbuf = [0u8; SCRATCH_BUF_BYTES];
@@ -495,7 +496,9 @@ impl Session {
         gas_limit: u64,
     ) -> Result<CallReceipt<Vec<u8>>, Error> {
         if fn_name == INIT_METHOD {
-            return Err(InitalizationError("init call not allowed".into()));
+            return Err(Error::InitalizationError(
+                "init call not allowed".into(),
+            ));
         }
 
         let (data, gas_spent, call_tree) =

--- a/piecrust/src/store/commit.rs
+++ b/piecrust/src/store/commit.rs
@@ -199,6 +199,10 @@ impl Commit {
         ret
     }
 
+    pub fn contains_contract_position(&self, pos: u64) -> bool {
+        self.contracts_merkle.contains_position(pos)
+    }
+
     pub fn index_get(
         &self,
         contract_id: &ContractId,

--- a/piecrust/src/store/session.rs
+++ b/piecrust/src/store/session.rs
@@ -20,7 +20,7 @@ use crate::store::baseinfo::BaseInfo;
 use crate::store::commit::Commit;
 use crate::store::commit_store::CommitStore;
 use crate::store::hasher::Hash;
-use crate::store::tree::PageOpening;
+use crate::store::tree::{PageOpening, position_from_contract};
 use crate::store::{
     BASE_FILE, BYTECODE_DIR, Bytecode, Call, ELEMENT_FILE, MAIN_DIR,
     MEMORY_DIR, METADATA_EXTENSION, Memory, Metadata, Module,
@@ -372,6 +372,72 @@ impl ContractSession {
         }
     }
 
+    fn pending_contract_position_occupied(
+        &self,
+        contract_id: ContractId,
+        pos: u64,
+        ignored_contract: Option<ContractId>,
+    ) -> bool {
+        // Pending contracts are not inserted into ContractsMerkle until root,
+        // memory_pages, or commit builds a Commit. Until then, self.contracts
+        // is the only place where same-session deployments can be
+        // checked.
+        self.contracts.keys().any(|id| {
+            *id != contract_id
+                && Some(*id) != ignored_contract
+                && position_from_contract(id) == pos
+        })
+    }
+
+    fn ensure_new_contract_position_available(
+        &self,
+        contract_id: ContractId,
+    ) -> Result<(), Error> {
+        let pos = position_from_contract(&contract_id);
+
+        // Deploy creates a new contract ID, so its Merkle position must be
+        // unused both in pending session state and in the committed base tree.
+        if self.pending_contract_position_occupied(contract_id, pos, None)
+            || self
+                .base
+                .as_ref()
+                .is_some_and(|base| base.contains_contract_position(pos))
+        {
+            return Err(Error::ContractPositionCollision { contract_id, pos });
+        }
+
+        Ok(())
+    }
+
+    fn ensure_replace_contract_position_available(
+        &self,
+        contract_id: ContractId,
+        replacement_contract: ContractId,
+    ) -> Result<(), Error> {
+        let pos = position_from_contract(&contract_id);
+
+        // Replace is used by migration: the target ID may already exist and, in
+        // that normal case, reusing its own base Merkle position is correct.
+        // The pending replacement ID is about to be removed and re-keyed to the
+        // target ID, so it must not count as a collision with the target.
+        // Reject only when the position belongs to a different pending/base ID.
+        let pending_collision = self.pending_contract_position_occupied(
+            contract_id,
+            pos,
+            Some(replacement_contract),
+        );
+        let base_collision = self.base.as_ref().is_some_and(|base| {
+            base.contains_contract_position(pos)
+                && base.index_get(&contract_id).is_none()
+        });
+
+        if pending_collision || base_collision {
+            return Err(Error::ContractPositionCollision { contract_id, pos });
+        }
+
+        Ok(())
+    }
+
     /// Deploys bytecode to the contract store with the given its `contract_id`.
     ///
     /// See [`deploy`] for deploying bytecode without specifying a contract ID.
@@ -384,21 +450,31 @@ impl ContractSession {
         module: B,
         metadata: ContractMetadata,
         metadata_bytes: B,
-    ) -> io::Result<()> {
-        let bytecode = Bytecode::new(bytecode)?;
-        let module = Module::new(&self.engine, module)?;
-        let metadata = Metadata::new(metadata_bytes, metadata)?;
-        let memory = Memory::new(module.is_64())?;
+    ) -> Result<(), Error> {
+        let persistence_error = |err: io::Error| -> Error {
+            Error::PersistenceError(Arc::new(err))
+        };
+        let bytecode = Bytecode::new(bytecode).map_err(persistence_error)?;
+        let module =
+            Module::new(&self.engine, module).map_err(persistence_error)?;
+        let metadata = Metadata::new(metadata_bytes, metadata)
+            .map_err(persistence_error)?;
+        let memory = Memory::new(module.is_64()).map_err(persistence_error)?;
 
-        // If the position is already filled in the tree, the contract cannot be
-        // inserted.
-        if let Some(base) = self.base.as_ref()
-            && base.index_get(&contract_id).is_some()
+        // Deploy creates a new contract ID, so exact ID reuse is rejected here.
+        // Folded Merkle-position reuse is checked separately below.
+        if self.contracts.contains_key(&contract_id)
+            || self
+                .base
+                .as_ref()
+                .is_some_and(|base| base.index_get(&contract_id).is_some())
         {
-            return Err(io::Error::other(format!(
+            return Err(persistence_error(io::Error::other(format!(
                 "Existing contract '{contract_id}'"
-            )));
+            ))));
         }
+
+        self.ensure_new_contract_position_available(contract_id)?;
 
         self.contracts.insert(
             contract_id,
@@ -422,6 +498,17 @@ impl ContractSession {
         old_contract: ContractId,
         new_contract: ContractId,
     ) -> Result<(), Error> {
+        if !self.contracts.contains_key(&new_contract) {
+            return Err(Error::PersistenceError(Arc::new(io::Error::other(
+                format!("Contract '{new_contract}' not found"),
+            ))));
+        }
+
+        self.ensure_replace_contract_position_available(
+            old_contract,
+            new_contract,
+        )?;
+
         let mut new_contract_data =
             self.contracts.remove(&new_contract).ok_or_else(|| {
                 Error::PersistenceError(Arc::new(io::Error::other(format!(

--- a/piecrust/src/store/tree.rs
+++ b/piecrust/src/store/tree.rs
@@ -115,6 +115,10 @@ impl ContractsMerkle {
         self.tree_pos.insert(int_pos as u32, (hash, pos));
     }
 
+    pub fn contains_position(&self, pos: u64) -> bool {
+        self.dict.contains_key(&pos)
+    }
+
     pub fn opening(&self, pos: u64) -> Option<TreeOpening> {
         let new_pos = self.dict.get(&pos)?;
         self.inner_tree.opening(*new_pos)

--- a/piecrust/tests/deploy.rs
+++ b/piecrust/tests/deploy.rs
@@ -84,3 +84,87 @@ fn call_non_deployed() -> Result<(), Error> {
 
     Ok(())
 }
+
+#[test]
+fn contract_id_position_collision_is_rejected() -> Result<(), Error> {
+    let vm = VM::ephemeral()?;
+    let mut session = vm.session(SessionData::builder())?;
+
+    let id_a = ContractId::from_bytes([0; 32]);
+
+    // Both IDs map to the same contract Merkle position: id_a sums to zero,
+    // while id_b sums to 1 + u32::MAX, which wraps back to zero.
+    let mut id_b_bytes = [0u8; 32];
+    id_b_bytes[0..4].copy_from_slice(&1u32.to_le_bytes());
+    id_b_bytes[4..8].copy_from_slice(&u32::MAX.to_le_bytes());
+    let id_b = ContractId::from_bytes(id_b_bytes);
+
+    assert_ne!(id_a, id_b);
+
+    session.deploy::<_, (), _>(
+        contract_bytecode!("counter"),
+        ContractData::builder().owner(OWNER).contract_id(id_a),
+        LIMIT,
+    )?;
+
+    let err = session
+        .deploy::<_, (), _>(
+            contract_bytecode!("box"),
+            ContractData::builder().owner(OWNER).contract_id(id_b),
+            LIMIT,
+        )
+        .expect_err("colliding contract id should be rejected");
+
+    assert!(matches!(
+        err,
+        Error::ContractPositionCollision {
+            contract_id,
+            pos: 0,
+        } if contract_id == id_b
+    ));
+
+    Ok(())
+}
+
+#[test]
+fn contract_id_position_collision_with_base_is_rejected() -> Result<(), Error> {
+    let vm = VM::ephemeral()?;
+
+    let id_a = ContractId::from_bytes([0; 32]);
+
+    // Both IDs map to the same contract Merkle position: id_a sums to zero,
+    // while id_b sums to 1 + u32::MAX, which wraps back to zero.
+    let mut id_b_bytes = [0u8; 32];
+    id_b_bytes[0..4].copy_from_slice(&1u32.to_le_bytes());
+    id_b_bytes[4..8].copy_from_slice(&u32::MAX.to_le_bytes());
+    let id_b = ContractId::from_bytes(id_b_bytes);
+
+    assert_ne!(id_a, id_b);
+
+    let mut session = vm.session(SessionData::builder())?;
+    session.deploy::<_, (), _>(
+        contract_bytecode!("counter"),
+        ContractData::builder().owner(OWNER).contract_id(id_a),
+        LIMIT,
+    )?;
+    let root = session.commit()?;
+
+    let mut session = vm.session(SessionData::builder().base(root))?;
+    let err = session
+        .deploy::<_, (), _>(
+            contract_bytecode!("box"),
+            ContractData::builder().owner(OWNER).contract_id(id_b),
+            LIMIT,
+        )
+        .expect_err("contract id colliding with base should be rejected");
+
+    assert!(matches!(
+        err,
+        Error::ContractPositionCollision {
+            contract_id,
+            pos: 0,
+        } if contract_id == id_b
+    ));
+
+    Ok(())
+}

--- a/piecrust/tests/persistence.rs
+++ b/piecrust/tests/persistence.rs
@@ -316,3 +316,141 @@ fn migration_self_id_remains_same() -> Result<(), Error> {
 
     Ok(())
 }
+
+#[test]
+fn migration_to_contract_id_pos_collision_is_rejected() -> Result<(), Error> {
+    let vm = VM::ephemeral()?;
+
+    // Normal migration replaces bytecode at an existing contract ID. This test
+    // covers the edge case where migration targets an absent ID; in that case,
+    // replace can effectively introduce a new final contract ID and must not be
+    // allowed to introduce a Merkle-position collision with an existing ID.
+    let id_a = ContractId::from_bytes([0; 32]);
+
+    // Both IDs map to the same contract Merkle position: id_a sums to zero,
+    // while id_b sums to 1 + u32::MAX, which wraps back to zero.
+    let mut id_b_bytes = [0u8; 32];
+    id_b_bytes[0..4].copy_from_slice(&1u32.to_le_bytes());
+    id_b_bytes[4..8].copy_from_slice(&u32::MAX.to_le_bytes());
+    let id_b = ContractId::from_bytes(id_b_bytes);
+
+    assert_ne!(id_a, id_b);
+
+    let mut session = vm.session(SessionData::builder())?;
+    session.deploy::<_, (), _>(
+        contract_bytecode!("counter"),
+        ContractData::builder().owner(OWNER).contract_id(id_b),
+        LIMIT,
+    )?;
+    let root = session.commit()?;
+
+    let session = vm.session(SessionData::builder().base(root))?;
+    let err = session
+        .migrate(
+            id_a,
+            contract_bytecode!("box"),
+            ContractData::builder().owner(OWNER),
+            LIMIT,
+            |_, _| Ok(()),
+        )
+        .expect_err("migration to colliding contract id should be rejected");
+
+    assert!(matches!(
+        err,
+        Error::ContractPositionCollision {
+            contract_id,
+            pos: 0,
+        } if contract_id == id_a
+    ));
+
+    Ok(())
+}
+
+#[test]
+fn migration_to_pending_id_pos_collision_is_rejected() -> Result<(), Error> {
+    let vm = VM::ephemeral()?;
+
+    let id_a = ContractId::from_bytes([0; 32]);
+
+    // Both IDs map to the same contract Merkle position: id_a sums to zero,
+    // while id_b sums to 1 + u32::MAX, which wraps back to zero.
+    let mut id_b_bytes = [0u8; 32];
+    id_b_bytes[0..4].copy_from_slice(&1u32.to_le_bytes());
+    id_b_bytes[4..8].copy_from_slice(&u32::MAX.to_le_bytes());
+    let id_b = ContractId::from_bytes(id_b_bytes);
+
+    // The temporary migration deployment must use a distinct non-colliding
+    // position so the test reaches replace's pending-collision guard.
+    let mut temp_id_bytes = [0u8; 32];
+    temp_id_bytes[0..4].copy_from_slice(&2u32.to_le_bytes());
+    let temp_id = ContractId::from_bytes(temp_id_bytes);
+
+    assert_ne!(id_a, id_b);
+    assert_ne!(id_a, temp_id);
+    assert_ne!(id_b, temp_id);
+
+    let mut session = vm.session(SessionData::builder())?;
+    session.deploy::<_, (), _>(
+        contract_bytecode!("counter"),
+        ContractData::builder().owner(OWNER).contract_id(id_b),
+        LIMIT,
+    )?;
+
+    let err = session
+        .migrate(
+            id_a,
+            contract_bytecode!("box"),
+            ContractData::builder().owner(OWNER).contract_id(temp_id),
+            LIMIT,
+            |_, _| Ok(()),
+        )
+        .expect_err(
+            "migration to id colliding with pending contract should fail",
+        );
+
+    assert!(matches!(
+        err,
+        Error::ContractPositionCollision {
+            contract_id,
+            pos: 0,
+        } if contract_id == id_a
+    ));
+
+    Ok(())
+}
+
+#[test]
+fn migration_allows_replacement_contract_at_target_pos() -> Result<(), Error> {
+    let vm = VM::ephemeral()?;
+
+    let id_a = ContractId::from_bytes([0; 32]);
+
+    // The replacement's temporary ID maps to the same contract Merkle position
+    // as the final target ID. This is allowed because replace removes the
+    // temporary ID before inserting the contract data at the target ID.
+    let mut temp_id_bytes = [0u8; 32];
+    temp_id_bytes[0..4].copy_from_slice(&1u32.to_le_bytes());
+    temp_id_bytes[4..8].copy_from_slice(&u32::MAX.to_le_bytes());
+    let temp_id = ContractId::from_bytes(temp_id_bytes);
+
+    assert_ne!(id_a, temp_id);
+
+    let session = vm.session(SessionData::builder())?;
+    let mut session = session.migrate(
+        id_a,
+        contract_bytecode!("box"),
+        ContractData::builder().owner(OWNER).contract_id(temp_id),
+        LIMIT,
+        |_, _| Ok(()),
+    )?;
+
+    session.call::<i16, ()>(id_a, "set", &0x11, LIMIT)?;
+    assert_eq!(
+        session
+            .call::<_, Option<i16>>(id_a, "get", &(), LIMIT)?
+            .data,
+        Some(0x11)
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Add missing check to reject deployment of a contract that maps to an unavailable Merkle position.
